### PR TITLE
Use test template in test test content

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Behat/BaseStructureContext.php
+++ b/src/Sulu/Bundle/ContentBundle/Behat/BaseStructureContext.php
@@ -146,6 +146,10 @@ class BaseStructureContext extends BaseContext implements SnippetAcceptingContex
     {
         $paths = $this->getContainer()->getParameter('sulu.content.structure.paths');
         $paths = array_filter($paths, function ($value) use ($type) {
+            if (true === $value['internal']) {
+                return false;
+            }
+
             if ($value['type'] == $type) {
                 return true;
             }
@@ -160,12 +164,7 @@ class BaseStructureContext extends BaseContext implements SnippetAcceptingContex
             ));
         }
 
-        if (isset($paths[0])) {
-            $path = $paths[0];
-        } else {
-            $path = reset($paths);
-        }
-
+        $path = reset($paths);
         $templatePath = $path['path'] . '/' . $name . '.xml';
         $this->templatePaths[$templatePath] = true;
         file_put_contents($templatePath, $template);

--- a/src/Sulu/Bundle/ContentBundle/Behat/ContentContext.php
+++ b/src/Sulu/Bundle/ContentBundle/Behat/ContentContext.php
@@ -38,7 +38,7 @@ class ContentContext extends BaseStructureContext implements SnippetAcceptingCon
 
     <key>%s</key>
 
-    <view>SuluTestBundle::content_test</view>
+    <view>@sulu_test_bundle/content_test</view>
     <controller>SuluWebsiteBundle:Default:index</controller>
     <cacheLifetime>2400</cacheLifetime>
 


### PR DESCRIPTION
Use an aliased template name in the generated content for the
behat tests. This template needs to be included in the configuration
of Sulu standard.

See: https://github.com/sulu-cmf/sulu-standard/pull/402

Can be merged now.