### PR TITLE
fixed select all for permission-tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #970 [SecurityBundle]  Fixed select all bug in permissions tab
     * FEATURE     #941 [SecurityBundle]  Adding permissions on an object basis
     * FEATURE     #931 [MediaBundle]     Version History Tab
     * FEATURE     #923 [ContactBundle]   Extract CRM to own Bundles

--- a/src/Sulu/Bundle/SecurityBundle/Resources/public/js/components/permission-tab/components/form/main.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/public/js/components/permission-tab/components/form/main.js
@@ -125,7 +125,17 @@ define(['config', 'sulusecurity/collections/roles'], function(Config, Roles) {
         },
 
         changePermission = function(data) {
-            permissionData.permissions[data.section][data.value] = data.activated;
+            if (typeof(data.value) === 'string') {
+                setPermission.call(this, data.section, data.value, data.activated);
+            } else {
+                this.sandbox.dom.each(data.value, function(index, value) {
+                    setPermission.call(this, data.section, value.value, data.activated);
+                });
+            }
+        },
+
+        setPermission = function(section, value, activated) {
+            permissionData.permissions[section][value] = activated;
         },
 
         save = function() {


### PR DESCRIPTION
Fixed small bug, which prevented the "Select All" and "Select None" in the matrix to be working.