### PR TITLE
Improved test speed

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
+++ b/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
@@ -94,21 +94,6 @@ class SecurityContext extends BaseContext implements SnippetAcceptingContext
     public function iAmLoggedInAsAnAdministrator()
     {
         $this->theUserExistsWithPassword('admin', 'admin');
-        $this->visitPath('/admin');
-        $page = $this->getSession()->getPage();
-        $this->waitForSelector('#username');
-        $this->fillSelector('#username', 'admin');
-        $this->fillSelector('#password', 'admin');
-        $loginButton = $page->findById('login-button');
-
-        if (!$loginButton) {
-            throw new \InvalidArgumentException(
-                'Could not find submit button on login page'
-            );
-        }
-        
-        $loginButton->click();
-        $this->getSession()->wait(5000, "document.querySelector('.navigation')");
     }
 
     private function getOrCreateRole($name, $system)

--- a/src/Sulu/Bundle/TestBundle/Behat/BaseContext.php
+++ b/src/Sulu/Bundle/TestBundle/Behat/BaseContext.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
-use Behat\MinkExtension\Context\MinkContext;
 use Symfony\Component\Console\Output\NullOutput;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/src/Sulu/Bundle/TestBundle/Behat/MinkContext.php
+++ b/src/Sulu/Bundle/TestBundle/Behat/MinkContext.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sulu\Bundle\TestBundle\Behat;
+
+use Behat\MinkExtension\Context\MinkContext as BaseMinkContext;
+
+class MinkContext extends BaseMinkContext
+{
+    public function visit($page)
+    {
+        $currentUrl = $this->getCurrentUrl();
+        if ($currentUrl == $page) {
+            $this->getSession()->reload();
+            return;
+        }
+
+        parent::visit($page);
+    }
+
+
+    protected function getCurrentUrl()
+    {
+        $parts = parse_url($this->getSession()->getCurrentUrl());
+        $currentUrl = $parts['path'];
+
+        if (isset($parts['query'])) {
+            $currentUrl .= '?' . $parts['query'];
+        }
+
+        if (isset($parts['fragment'])) {
+            $currentUrl .= '#' . $parts['fragment'];
+        }
+
+        return $currentUrl;
+    }
+}


### PR DESCRIPTION
Improve speed (and hopefully stability) of behat tests:

- Use HTTP authentication for login (by installing custom `config.local.yml`
- Use "refresh" instead of "visiit" if the current URL is the same as the requested one.