### PR TITLE
Set functional defaults for media headers and ghostscript path 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #988 [MediaBundle]     Set working defaults for ghostscript and caching headers
     * BUGFIX      #976 [MediaBundle]     Fix media scale mode parameter
     * FEATURE     #975 [MediaBundle]     Make Storage path and segments configurateable
     * BUGFIX      #973 [All]             Added handling of anonymous user token

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('ghost_script')
                 ->addDefaultsIfNotSet()
                 ->children()
-                     ->scalarNode('path')->defaultValue(SuluMediaExtension::DEFAULT_GHOST_SCRIPT_PATH)->end()
+                     ->scalarNode('path')->defaultValue('gs')->end()
                 ->end()
             ->end()
             ->arrayNode('storage')
@@ -57,7 +57,11 @@ class Configuration implements ConfigurationInterface
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->arrayNode('response_headers')
-                        ->prototype('scalar')->end()
+                        ->prototype('scalar')->end()->defaultValue(array(
+                            'Expires' => '+1 month',
+                            'Pragma' => 'public',
+                            'Cache-Control' => 'public'
+                        ))
                     ->end()
                     ->arrayNode('default_imagine_options')
                         ->prototype('scalar')->end()

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -23,7 +23,6 @@ use Symfony\Component\DependencyInjection\Loader;
 class SuluMediaExtension extends Extension
 {
     const DEFAULT_FORMAT_NAME = '170x170';
-    const DEFAULT_GHOST_SCRIPT_PATH = 'ghostscript';
     const DEFAULT_FORMAT_CACHE_PUBLIC_FOLDER = 'web';
 
     /**


### PR DESCRIPTION
__Tasks:__

- [x] test coverage
- [ ] gather feedback for my changes
- [x] added changelog line

__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | fixes #983, fixes #982 
| BC Breaks     | yes?
| Doc           | none

Part of: https://github.com/sulu-io/sulu-standard/pull/437/files