### PR TITLE
Changed internal link title for navigation, smartcontent and internal link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1002[ContentBundle]   Changed internal link title for navigation, smartcontent and internal link
     * BUGFIX      #952 [MediaBundle]     Fix coffee icon fallback in media thumbnail view
     * ENHANCEMENT #951 [MediaBundle]     Made path to image-formats.xml configurateable
     * BUGFIX      #968 [MediaBundle]     Add wildcard support for media type check

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## dev-develop
 
+### Content
+
+Behaviour of internal links has changed. It returns the link title for navigation/smartcontent/internal-link.
+
 ### Media Types
 
 The media types are now set by wildcard check and need to be updated,

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="abaaaaa371239fbed4a73a4123dfdf010" resname="sulu.content.form.settings.type.internal-link.title">
                 <source>sulu.content.form.settings.type.internal-link.title</source>
-                <target>Titel</target>
+                <target>Link Titel</target>
             </trans-unit>
             <trans-unit id="abaaaaa371239fbed4a73a4123dfdf011" resname="sulu.content.form.settings.type.internal-link.link">
                 <source>sulu.content.form.settings.type.internal-link.link</source>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="abaaaaa371239fbed4a73a4123dfdf010" resname="sulu.content.form.settings.type.internal-link.title">
                 <source>sulu.content.form.settings.type.internal-link.title</source>
-                <target>Title</target>
+                <target>Link title</target>
             </trans-unit>
             <trans-unit id="abaaaaa371239fbed4a73a4123dfdf011" resname="sulu.content.form.settings.type.internal-link.link">
                 <source>sulu.content.form.settings.type.internal-link.link</source>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -351,13 +351,13 @@ class SitemapGeneratorTest extends PhpcrTestCase
         $this->assertEquals('News-1 en', $result[2]['title']);
         $this->assertEquals('News-2 en', $result[3]['title']);
         $this->assertEquals('Products-2 en', $result[4]['title']);
-        $this->assertEquals('News en', $result[5]['title']);
+        $this->assertEquals('Products-3 en', $result[5]['title']);
         $this->assertEquals('News en_us', $result[6]['title']);
         $this->assertEquals('News-1 en_us', $result[7]['title']);
         $this->assertEquals('News-2 en_us', $result[8]['title']);
         // Products-1 en/en_us is a internal link to the unpublished page products (not in result)
         $this->assertEquals('Products-2 en_us', $result[9]['title']);
-        $this->assertEquals('News en_us', $result[10]['title']);
+        $this->assertEquals('Products-3 en_us', $result[10]['title']);
 
         $this->assertEquals('/', $result[0]['url']);
         $this->assertEquals('/news', $result[1]['url']);
@@ -394,7 +394,7 @@ class SitemapGeneratorTest extends PhpcrTestCase
         $this->assertEquals('News-1 en', $result[2]['title']);
         $this->assertEquals('News-2 en', $result[3]['title']);
         $this->assertEquals('Products-2 en', $result[4]['title']);
-        $this->assertEquals('News en', $result[5]['title']);
+        $this->assertEquals('Products-3 en', $result[5]['title']);
 
         $this->assertEquals('/', $result[0]['url']);
         $this->assertEquals('/news', $result[1]['url']);
@@ -432,7 +432,7 @@ class SitemapGeneratorTest extends PhpcrTestCase
         $this->assertEquals(4, $layer1[1]['nodeType']);
         $this->assertEquals('http://www.asdf.at', $layer1[1]['url']);
 
-        $this->assertEquals('News en', $layer1[2]['title']);
+        $this->assertEquals('Products-3 en', $layer1[2]['title']);
         $this->assertEquals('/news', $layer1[2]['url']);
         $this->assertEquals(2, $layer1[2]['nodeType']);
 

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -2187,6 +2187,7 @@ class ContentMapper implements ContentMapperInterface
             $node->hasProperty($propertyTranslator->getName('template')) &&
             $node->hasProperty($propertyTranslator->getName('nodeType'))
         ) {
+            $originalNode = $node;
             if (
                 $node->getPropertyValue($propertyTranslator->getName('nodeType')) === Structure::NODE_TYPE_INTERNAL_LINK
             ) {
@@ -2280,7 +2281,7 @@ class ContentMapper implements ContentMapperInterface
                         'created' => $created,
                         'published' => $published,
                         'creator' => $creator,
-                        'title' => $this->getTitle($node, $structure, $webspaceKey, $locale),
+                        'title' => $this->getTitle($originalNode, $structure, $webspaceKey, $locale),
                         'url' => $url,
                         'urls' => $this->getLocalizedUrlsForPage($structure, $node, $webspaceKey, null),
                         'locale' => $locale,

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -2231,7 +2231,7 @@ class ContentMapper implements ContentMapperInterface
 
             $nodeState = $node->getPropertyValue($propertyTranslator->getName('state'));
 
-            // if page is not piblished ignore it
+            // if page is not published ignore it
             if ($nodeState !== Structure::STATE_PUBLISHED) {
                 return false;
             }


### PR DESCRIPTION
__Tasks:__

- [x] test coverage
- [ ] gather feedback for my changes
- [x] added changelog line


__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | fixes sulu-io/sulu-standard#423
| BC Breaks     | yes => UPGRADE
| Doc           | none