### PR TITLE
[ENHANCEMENT] Use tagged services instead of prefix for image converter commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #1055 [MediaBundle]    Use tagged services instead of prefix for image converter commands
     * BUGFIX      #1075 [WebsiteBundle]  Fixed sitemap add validation for requested domain
     * BUGFIX      #1124 [ContentBundle]  Fixed preview with multiple blocks
     * BUGFIX      #1123 [ContentBundle]  Fixed block behaviour on template change

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -72,6 +72,30 @@ The `Sulu` prefix from all `ContentNavigationProviders` and `Admin` classes has
 been removed. You have to change these names in all usages of this classes in
 your own code.
 
+### Media image converter commands
+
+The image converter commands are now handled via service container tags. No need for the 
+`sulu_media.image.command.prefix` anymore. If you have created your own command, you have to
+tag your image converter command service with `sulu_media.image.command`.
+
+Before:
+
+```xml
+<services>
+    <service id="%sulu_media.image.command.prefix%blur" class="%acme.image.command.blur.class%" />
+</services>
+```
+
+Change to:
+
+```xml
+<services>
+    <service id="acme.image.command.blur" class="%acme.image.command.blur.class%">
+        <tag name="sulu_media.image.command" alias="resize" />
+    </service>
+</services>
+```
+
 ### Media preview urls
 
 The thumbnail url will only be generated for supported mime-types. Otherwise it returns a zero length array.

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageCommandCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageCommandCompilerPass.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass for collecting services tagged with sulu_media.image.command
+ */
+class ImageCommandCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('sulu_media.image.command_manager')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('sulu_media.image.command_manager');
+        $taggedServices = $container->findTaggedServiceIds('sulu_media.image.command');
+
+        foreach ($taggedServices as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $definition->addMethodCall(
+                    'add',
+                    array(new Reference($id), $attributes['alias'])
+                );
+            }
+        }
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -45,7 +45,6 @@ class SuluMediaExtension extends Extension
         $container->setParameter('sulu_media.format_cache.segments', $config['format_cache']['segments']);
 
         // converter
-        $container->setParameter('sulu_media.image.command.prefix', 'image.converter.prefix.');
         $container->setParameter('sulu_media.ghost_script.path', $config['ghost_script']['path']);
 
         // storage

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Command/Manager/CommandManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Command/Manager/CommandManager.php
@@ -11,33 +11,43 @@
 namespace Sulu\Bundle\MediaBundle\Media\ImageConverter\Command\Manager;
 
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\Command\CommandInterface;
-use Symfony\Component\DependencyInjection\ContainerAware;
 
 /**
  * Default implementation of command manager.
  */
-class CommandManager extends ContainerAware implements ManagerInterface
+class CommandManager implements ManagerInterface
 {
     /**
-     * @var string The prefix to load the image command
+     * @var CommandInterface[]
      */
-    private $prefix;
+    private $commands = array();
 
     /**
-     * @param string $prefix
+     * @param CommandInterface $command
+     *
+     * @param string $alias
      */
-    public function __construct($prefix)
+    public function add(CommandInterface $command, $alias)
     {
-        $this->prefix = $prefix;
+        $this->commands[$alias] = $command;
     }
 
     /**
-     * @param string $imageCommandName A String with the name of the image command to load
+     * @param string $name A String with the name of the image command to load
      *
      * @return CommandInterface
+     *
+     * @throws \InvalidArgumentException If the command doesn't exist
      */
-    public function get($imageCommandName = '')
+    public function get($name)
     {
-        return $this->container->get($this->prefix . $imageCommandName);
+        if (array_key_exists($name, $this->commands)) {
+            return $this->commands[$name];
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'A image converter command named "%s" does not exist.',
+            $name
+        ));
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -62,21 +62,17 @@
             <argument type="service" id="sulu_media.image.command_manager" />
         </service>
 
-        <service id="sulu_media.image.command_manager" class="%sulu_media.image.command_manager.class%">
-            <argument>%sulu_media.image.command.prefix%</argument>
+        <service id="sulu_media.image.command_manager" class="%sulu_media.image.command_manager.class%" />
 
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
+        <service id="sulu_media.image.command.resize" class="%sulu_media.image.command.resize.class%">
+            <tag name="sulu_media.image.command" alias="resize" />
         </service>
-
-        <service id="sulu_media.image.command.resize" class="%sulu_media.image.command.resize.class%" />
-        <service id="sulu_media.image.command.scale" class="%sulu_media.image.command.scale.class%" />
-        <service id="sulu_media.image.command.crop" class="%sulu_media.image.command.crop.class%" />
-
-        <service id="%sulu_media.image.command.prefix%scale" alias="sulu_media.image.command.scale" />
-        <service id="%sulu_media.image.command.prefix%resize" alias="sulu_media.image.command.resize" />
-        <service id="%sulu_media.image.command.prefix%crop" alias="sulu_media.image.command.crop" />
+        <service id="sulu_media.image.command.scale" class="%sulu_media.image.command.scale.class%">
+            <tag name="sulu_media.image.command" alias="scale" />
+        </service>
+        <service id="sulu_media.image.command.crop" class="%sulu_media.image.command.crop.class%">
+            <tag name="sulu_media.image.command" alias="crop" />
+        </service>
 
         <service id="sulu_media.media_manager" class="%sulu_media.media_manager.class%">
             <argument type="service" id="sulu_media.media_repository" />

--- a/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
+++ b/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
@@ -10,6 +10,7 @@
 
 namespace Sulu\Bundle\MediaBundle;
 
+use Sulu\Bundle\MediaBundle\DependencyInjection\ImageCommandCompilerPass;
 use Sulu\Bundle\MediaBundle\DependencyInjection\ImageFormatCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -21,5 +22,6 @@ class SuluMediaBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new ImageFormatCompilerPass());
+        $container->addCompilerPass(new ImageCommandCompilerPass());
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/ImageCommandCompilerPassTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/ImageCommandCompilerPassTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sulu\Bundle\MediaBundle\DependencyInjection\ImageCommandCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Test the image command compiler pass
+ */
+class ImageCommandCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ImageCommandCompilerPass());
+    }
+
+    /**
+     * @test
+     */
+    public function if_compiler_pass_collects_services_by_adding_method_calls_these_will_exist()
+    {
+        $commandManager = new Definition();
+        $this->setDefinition('sulu_media.image.command_manager', $commandManager);
+
+        $command = new Definition();
+        $command->addTag('sulu_media.image.command', array('alias' => 'resize'));
+        $this->setDefinition('sulu_media.image.command.resize', $command);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sulu_media.image.command_manager',
+            'add',
+            array(
+                new Reference('sulu_media.image.command.resize'),
+                'resize'
+            )
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
@@ -40,7 +40,6 @@ class SuluMediaExtensionTest extends AbstractExtensionTestCase
         ));
         $this->assertContainerBuilderHasParameter('sulu_media.format_cache.save_image', true);
         $this->assertContainerBuilderHasParameter('sulu_media.format_cache.path', '%kernel.root_dir%/../web/uploads/media');
-        $this->assertContainerBuilderHasParameter('sulu_media.image.command.prefix', 'image.converter.prefix.');
         $this->assertContainerBuilderHasParameter('sulu_media.media.blocked_file_types', array('file/exe'));
         $this->assertContainerBuilderHasParameter('sulu_media.ghost_script.path', 'gs');
         $this->assertContainerBuilderHasParameter('sulu_media.format_manager.mime_types',  array(


### PR DESCRIPTION
The image converter commands are now handled via the `sulu_media.image.command` service container tag. No need for the 
`sulu_media.image.command.prefix` anymore.

__Tasks:__

- [x] Add entry to `CHANGELOG.md`

__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | #1032 
| BC Breaks     | yes, if application devs created own image converter commands
| Doc           | none
| License | MIT