### PR TITLE
Webspace key index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* 0.18.1 (2015-05-09)
+    * HOTFIX      #1079 [SearchBundle]   Fix webspace-key index for content pages
+
 * 0.18.0 (2015-05-08)
     * ENHANCEMENT #797  [SearchBundle]   Rebuild command removed, now hooks into massive:search:index:rebuild
     * ENHANCEMENT #797  [SearchBundle]   Unpublished pages are no longer deindexed - a "state" field has been added, see UPGRADE.md

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureDriver.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureDriver.php
@@ -157,7 +157,7 @@ class StructureDriver implements AdvancedDriverInterface
 
         $indexMeta->addFieldMapping('state', array(
             'type' => 'string',
-            'index_strategy' => Field::INDEX_UNSTORED,
+            'index_strategy' => Field::INDEX_STORED_INDEXED,
             'field' => $this->factory->createMetadataExpression('object.nodeState == 1 ? "test" : "published"'),
         ));
 

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureDriver.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureDriver.php
@@ -151,7 +151,7 @@ class StructureDriver implements AdvancedDriverInterface
         // index the webspace
         $indexMeta->addFieldMapping('webspace_key', array(
             'type' => 'string',
-            'index_strategy' => Field::INDEX_UNSTORED,
+            'index_strategy' => Field::INDEX_AGGREGATE,
             'field' => $this->factory->createMetadataProperty('webspaceKey'),
         ));
 

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureDriver.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureDriver.php
@@ -151,7 +151,7 @@ class StructureDriver implements AdvancedDriverInterface
         // index the webspace
         $indexMeta->addFieldMapping('webspace_key', array(
             'type' => 'string',
-            'index_strategy' => Field::INDEX_AGGREGATE,
+            'index_strategy' => Field::INDEX_STORED_INDEXED,
             'field' => $this->factory->createMetadataProperty('webspaceKey'),
         ));
 


### PR DESCRIPTION
Why is the webspace key index to unstored? does this mean that it is not stored in the index? @danrot @dantleech @chirimoya 

__tasks:__

- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none