### PR TITLE
added an event for updated permissions

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -99,6 +99,7 @@
         <service id="sulu_security.access_control_manager" class="%sulu_security.access_control_manager.class%">
             <argument type="service" id="security.acl.provider"/>
             <argument type="service" id="sulu_security.mask_converter"/>
+            <argument type="service" id="event_dispatcher"/>
             <tag name="sulu.context" context="admin"/>
         </service>
 

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SymfonyAccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SymfonyAccessControlManager.php
@@ -42,6 +42,11 @@ class SymfonyAccessControlManager implements AccessControlManagerInterface
      */
     private $eventDispatcher;
 
+    /**
+     * @param MutableAclProviderInterface $aclProvider
+     * @param MaskConverterInterface $maskConverter
+     * @param EventDispatcherInterface $eventDispatcher
+     */
     public function __construct(
         MutableAclProviderInterface $aclProvider,
         MaskConverterInterface $maskConverter,

--- a/src/Sulu/Component/Security/Event/PermissionUpdateEvent.php
+++ b/src/Sulu/Component/Security/Event/PermissionUpdateEvent.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * This file is part of Sulu
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace Sulu\Component\Security\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * This event is dispatched when any object permission have been updated
+ */
+class PermissionUpdateEvent extends Event
+{
+    /**
+     * The type of the object for which the permissions have been updated
+     * @var string
+     */
+    private $type;
+
+    /**
+     * The identifier of the object for which the permissions have been updated
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * The security identity for which the permissions have been updated
+     * @var string
+     */
+    private $securityIdentity;
+
+    /**
+     * The new updated permissions
+     * @var array
+     */
+    private $permissions;
+
+    /**
+     * @param string $type
+     * @param string $identifier
+     * @param string $securityIdentity
+     * @param array $permissions
+     */
+    public function __construct($type, $identifier, $securityIdentity, $permissions)
+    {
+        $this->type = $type;
+        $this->identifier = $identifier;
+        $this->securityIdentity = $securityIdentity;
+        $this->permissions = $permissions;
+    }
+
+    /**
+     * Returns the type of the object for which the permissions have been updated
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns the identifier of the object for which the permissions have been updated
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Returns the security identity for which the permissions have been updated
+     * @return string
+     */
+    public function getSecurityIdentity()
+    {
+        return $this->securityIdentity;
+    }
+
+    /**
+     * Returns the new updated permissions
+     * @return array
+     */
+    public function getPermissions()
+    {
+        return $this->permissions;
+    }
+}

--- a/src/Sulu/Component/Security/Event/SecurityEvents.php
+++ b/src/Sulu/Component/Security/Event/SecurityEvents.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * This file is part of Sulu
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace Sulu\Component\Security\Event;
+
+final class SecurityEvents
+{
+    /**
+     * The permission.update event is thrown when the AccessControlManager has updated some permissions.
+     * The event listener receives a PermissionUpdateEvent.
+     */
+    const PERMISSION_UPDATE = 'sulu.security.permission.update';
+}

--- a/tests/Sulu/Component/Security/Authorization/AccessControl/SymfonyAccessControlManagerTest.php
+++ b/tests/Sulu/Component/Security/Authorization/AccessControl/SymfonyAccessControlManagerTest.php
@@ -13,6 +13,8 @@ namespace Sulu\Component\Security\Authorization\AccessControl;
 use Prophecy\Argument;
 use Sulu\Component\Security\Authentication\SecurityIdentityInterface;
 use Sulu\Component\Security\Authorization\MaskConverterInterface;
+use Sulu\Component\Security\Event\PermissionUpdateEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Acl\Domain\Entry;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
@@ -49,6 +51,11 @@ class SymfonyAccessControlManagerTest extends \PHPUnit_Framework_TestCase
      */
     private $acl;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
     public function setUp()
     {
         parent::setUp();
@@ -57,10 +64,12 @@ class SymfonyAccessControlManagerTest extends \PHPUnit_Framework_TestCase
         $this->maskConverter = $this->prophesize(MaskConverterInterface::class);
         $this->securityIdentity = new RoleSecurityIdentity('SULU_ROLE_ADMINISTRATOR');
         $this->acl = $this->prophesize(MutableAclInterface::class);
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
 
         $this->accessControlManager = new SymfonyAccessControlManager(
             $this->aclProvider->reveal(),
-            $this->maskConverter->reveal()
+            $this->maskConverter->reveal(),
+            $this->eventDispatcher->reveal()
         );
     }
 
@@ -164,7 +173,9 @@ class SymfonyAccessControlManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetPermissionsWithoutExistingAcl($objectId, $objectType, $locale, $objectIdentifier)
     {
-        $this->aclProvider->findAcl(new ObjectIdentity($objectIdentifier, $objectType))->willThrow(AclNotFoundException::class);
+        $this->aclProvider->findAcl(new ObjectIdentity($objectIdentifier, $objectType))->willThrow(
+            AclNotFoundException::class
+        );
         $this->aclProvider->createAcl(new ObjectIdentity($objectIdentifier, $objectType))
             ->willReturn($this->acl->reveal())->shouldBeCalled();
         $this->aclProvider->updateAcl($this->acl->reveal())->shouldBeCalled();
@@ -172,6 +183,36 @@ class SymfonyAccessControlManagerTest extends \PHPUnit_Framework_TestCase
         $this->acl->getObjectAces()->willReturn(array());
 
         $this->acl->insertObjectAce(Argument::cetera())->shouldBeCalled();
+
+        $this->accessControlManager->setPermissions(
+            $objectType,
+            $objectId,
+            $this->securityIdentity,
+            array('view'),
+            $locale
+        );
+    }
+
+    /**
+     * @dataProvider provideObjectIdentifiers
+     */
+    public function testPermissionUpdateEvent($objectId, $objectType, $locale, $objectIdentifier)
+    {
+        $this->aclProvider->findAcl(new ObjectIdentity($objectIdentifier, $objectType))->willThrow(
+            AclNotFoundException::class
+        );
+        $this->aclProvider->createAcl(new ObjectIdentity($objectIdentifier, $objectType))
+            ->willReturn($this->acl->reveal())->shouldBeCalled();
+        $this->aclProvider->updateAcl($this->acl->reveal())->shouldBeCalled();
+
+        $this->acl->getObjectAces()->willReturn(array());
+
+        $this->acl->insertObjectAce(Argument::cetera())->shouldBeCalled();
+
+        $this->eventDispatcher->dispatch(
+            'sulu.security.permission.update',
+            new PermissionUpdateEvent($objectType, $objectIdentifier, $this->securityIdentity, array('view'))
+        )->shouldBeCalled();
 
         $this->accessControlManager->setPermissions(
             $objectType,


### PR DESCRIPTION
Adds the `sulu.security.permission.update` event, which will be required to copy some of the permission settings to other objects for better performance in lists.

__tasks:__

- [x] test coverage
- [x] gather feedback for my changes
- [x] submit changes to the documentation

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none