### PR TITLE
Added benchmarks

### DIFF
--- a/.phpbench.dist
+++ b/.phpbench.dist
@@ -1,0 +1,4 @@
+<?php
+
+require_once(__DIR__ . '/tests/bootstrap.php');
+require_once(__DIR__ . '/tests/app/AppKernel.php');

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_script:
 script: 
   - time ./bin/runtests.sh -i -a
   - phpunit
+  - phpbench run bench --report=
+  - ! 'php vendor/bin/phpbench run benchmark/ --report=''{"name": "console_table", "memory": true}'''
 
 matrix:
   allow_failures:

--- a/benchmark/ContentMapperBench.php
+++ b/benchmark/ContentMapperBench.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Sulu\Benchmark;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use PhpBench\Benchmark;
+use AppKernel;
+use PhpBench\Benchmark\Iteration;
+
+/**
+ * Benchmarking class for the content mapper
+ * Reuses the sulu test case class
+ */
+class ContentMapperBench extends SuluTestCase implements Benchmark
+{
+    private $contentMapper;
+    private $session;
+
+    public static function createKernel(array $options = array())
+    {
+        return new AppKernel('prod', true);
+    }
+
+    public function init()
+    {
+        $this->initPhpcr();
+        $this->contentMapper = $this->getContainer()->get('sulu.content.mapper');
+        $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
+    }
+
+    public function loadData(Iteration $iteration)
+    {
+        $data = array(
+            'title' => 'Testname',
+            'tags' => array(
+                'tag1',
+                'tag2'
+            ),
+            'url' => '/news/test',
+            'article' => 'default'
+        );
+
+        $structure = $this->contentMapper->save($data, 'overview', 'sulu_io', 'de', 1);
+        $iteration->setParameter('uuid', $structure->getUuid());
+        $this->session->refresh(false);
+    }
+
+    /**
+     * @description Save content
+     * @beforeMethod init
+     * @iterations 10
+     */
+    public function benchSave()
+    {
+        $data = array(
+            'title' => 'Testname',
+            'tags' => array(
+                'tag1',
+                'tag2'
+            ),
+            'url' => '/news/test',
+            'article' => 'default'
+        );
+
+        $this->contentMapper->save($data, 'overview', 'sulu_io', 'de', 1);
+    }
+
+    /**
+     * @description Load a single record
+     * @beforeMethod init
+     * @beforeMethod loadData
+     * @iterations 10
+     */
+    public function benchLoad(Iteration $iteration)
+    {
+        $this->contentMapper->load(
+            $iteration->getParameter('uuid'),
+            'sulu_io', 'de'
+        );
+    }
+
+    /**
+     * @description Load tree by path
+     * @beforeMethod init
+     * @beforeMethod loadData
+     * @iterations 10
+     */
+    public function benchLoadTreeByPath()
+    {
+        $this->contentMapper->loadTreeByPath('/', 'de', 'sulu_io');
+    }
+
+    /**
+     * @description Load by SQL2
+     * @beforeMethod init
+     * @beforeMethod loadData
+     */
+    public function benchLoadBySql2()
+    {
+        $sql2 = 'SELECT * FROM [nt:unstructured] WHERE [jcr:mixinTypes] = "sulu:page"';
+        $this->contentMapper->loadBySql2($sql2, 'de', 'sulu_io');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "pagerfanta/pagerfanta": "~1.0"
     },
     "require-dev": {
+        "dantleech/phpbench": "dev-master",
         "phpcr/phpcr-shell": "~1.0.0@alpha",
         "doctrine/doctrine-bundle": "1.4.*",
         "jackalope/jackalope-jackrabbit": "~1.2.0",
@@ -79,6 +80,14 @@
     "autoload": {
         "psr-0": {
             "Sulu\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "Sulu\\": "tests/"
+        },
+        "psr-4": {
+            "Sulu\\Benchmark\\": "benchmark/"
         }
     }
 }


### PR DESCRIPTION
This PR adds some benchmarks for the content mapper and adds them to the end of the .travis build (more for ensuring that they work rather than for gathering meaningful statistics).

Note this is currently more of an experiment and an RFC at least until there is a tagged version of phpbench.

