### PR TITLE
Do not try and determine the image URL for non-image media in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG for Sulu
                                          accounts cget action
     * ENHANCEMENT #1053 [Util]           Remove unused UuidUtils class
     * BUGFIX      #1051 [Website]        Throw NoValidWebspaceException if no valid webspaces are found
+    * BUGFIX      #1089 [Media/Search]   Do not set image URL for non-images in the search results
 
 * 0.18.1 (2015-05-09)
     * HOTFIX      #1079 [SearchBundle]   Fix webspace-key index for content pages

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/search.xml
@@ -20,6 +20,8 @@
         <service id="sulu_media.search.subscriber.media" class="%sulu_media.search.subscriber.media.class%" >
             <argument type="service" id="sulu_media.media_manager" />
             <argument type="service" id="massive_search.factory" />
+            <argument type="service" id="logger" />
+            <argument>%sulu_media.format_manager.mime_types%</argument>
             <argument>%sulu_media.search.default_image_format%</argument>
             <tag name="kernel.event_subscriber" />
         </service>

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
@@ -14,12 +14,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Massive\Bundle\SearchBundle\Search\SearchEvents;
 use Massive\Bundle\SearchBundle\Search\Event\PreIndexEvent;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Symfony\Component\PropertyAccess\PropertyAccess;
-use Sulu\Bundle\MediaBundle\Content\MediaSelectionContainer;
 use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Massive\Bundle\SearchBundle\Search\Factory;
+use Psr\Log\LoggerInterface;
 
 /**
  * This subscriber populates the image URL field
@@ -33,7 +31,8 @@ class MediaSearchSubscriber implements EventSubscriberInterface
     protected $mediaManager;
 
     /**
-     * The format of the image, which will be returned in the search
+     * The format of the image, which will be returned in the search.
+     *
      * @var string
      */
     protected $searchImageFormat;
@@ -44,18 +43,34 @@ class MediaSearchSubscriber implements EventSubscriberInterface
     protected $factory;
 
     /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var array
+     */
+    protected $thumbnailMimeTypes;
+
+    /**
      * @param MediaManagerInterface $mediaManager
      * @param Factory $factory Massive search factory
+     * @param LoggerInterface $logger
+     * @param $thumbnailMimeTypes
      * @param $searchImageFormat
      */
     public function __construct(
         MediaManagerInterface $mediaManager,
         Factory $factory,
+        LoggerInterface $logger,
+        $thumbnailMimeTypes,
         $searchImageFormat
     ) {
         $this->mediaManager = $mediaManager;
         $this->factory = $factory;
         $this->searchImageFormat = $searchImageFormat;
+        $this->thumbnailMimeTypes = $thumbnailMimeTypes;
+        $this->logger = $logger;
     }
 
     /**
@@ -69,7 +84,8 @@ class MediaSearchSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Adds the image to the search document
+     * Adds the image to the search document.
+     *
      * @param PreIndexEvent $event
      */
     public function handlePreIndex(PreIndexEvent $event)
@@ -78,8 +94,7 @@ class MediaSearchSubscriber implements EventSubscriberInterface
 
         if (
             false === $metadata->getClassMetadata()->reflection->isSubclassOf(FileVersionMeta::class)
-            && $metadata->getName() !== FileVersionMeta::class)
-        {
+            && $metadata->getName() !== FileVersionMeta::class) {
             return;
         }
 
@@ -91,7 +106,11 @@ class MediaSearchSubscriber implements EventSubscriberInterface
         $file = $fileVersion->getFile();
         $media = $file->getMedia();
 
-        $document->setImageUrl($this->getImageUrl($media, $locale));
+        // Do not try and get the image URL if the mime type is not in the 
+        // list of mime types for which thumbnails are generated.
+        if (in_array($fileVersion->getMimeType(), $this->thumbnailMimeTypes)) {
+            $document->setImageUrl($this->getImageUrl($media, $locale));
+        }
 
         $document->addField($this->factory->createField(
             'media_id',
@@ -123,9 +142,13 @@ class MediaSearchSubscriber implements EventSubscriberInterface
         $formats = $mediaApi->getThumbnails();
 
         if (!isset($formats[$this->searchImageFormat])) {
-            throw new \InvalidArgumentException(
-                sprintf('Search image format "%s" is not known', $this->searchImageFormat)
-            );
+            $this->logger->warning(sprintf(
+                'Media with ID "%s" does not have thumbnail format "%s". This thumbnail would be used by the search results.',
+                $media->getId(), 
+                $this->searchImageFormat
+            ));
+
+            return null;
         }
 
         return $formats[$this->searchImageFormat];

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
@@ -24,6 +24,7 @@ use Massive\Bundle\SearchBundle\Search\Metadata\IndexMetadata;
 use Massive\Bundle\SearchBundle\Search\Factory;
 use Massive\Bundle\SearchBundle\Search\Field;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Psr\Log\LoggerInterface;
 
 class MediaSearchSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -42,12 +43,14 @@ class MediaSearchSubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        parent::setUp();
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
+        $this->logger = $this->prophesize(LoggerInterface::class);
         $this->factory = $this->prophesize(Factory::class);
         $this->subscriber = new MediaSearchSubscriber(
             $this->mediaManager->reveal(),
             $this->factory->reveal(),
+            $this->logger->reveal(),
+            array('image/jpeg'),
             'test_format'
         );
 
@@ -94,15 +97,13 @@ class MediaSearchSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testSubscriber()
     {
-        $mediaId = 123;
-        $mediaMime = 'mime/type';
+        $this->setupSubscriber(
+            123,
+            'image/jpeg',
+            321
+        );
         $imageUrl = 'foo';
-        $collectionId = 321;
 
-        $this->reflection->isSubclassOf(FileVersionMeta::class)->willReturn(true);
-        $this->metadata->getName()->willReturn(FileVersionMeta::class);
-        $this->event->getSubject()->willReturn($this->fileVersionMeta->reveal());
-        $this->fileVersionMeta->getLocale()->willReturn('de');
         $this->mediaManager->addFormatsAndUrl(Argument::any())->will(function ($args) use ($imageUrl) {
             $mediaApi = $args[0];
             $mediaApi->setFormats(array(
@@ -111,18 +112,80 @@ class MediaSearchSubscriberTest extends \PHPUnit_Framework_TestCase
         });
 
 
-        $this->media->getId()->willReturn($mediaId);
-        $this->media->getCollection()->willReturn($this->collection->reveal());
-        $this->collection->getId()->willReturn($collectionId);
-        $this->fileVersion->getMimeType()->willReturn($mediaMime);
         $this->document->setImageUrl($imageUrl)->shouldBeCalled();
-        $this->factory->createField('media_id', $mediaId)->willReturn($this->field1->reveal());
-        $this->factory->createField('media_mime', $mediaMime)->willReturn($this->field2->reveal());
-        $this->factory->createField('collection_id', $collectionId)->willReturn($this->field3->reveal());
         $this->document->addField($this->field1->reveal())->shouldBeCalled();
         $this->document->addField($this->field2->reveal())->shouldBeCalled();
         $this->document->addField($this->field3->reveal())->shouldBeCalled();
 
         $this->subscriber->handlePreIndex($this->event->reveal());
+    }
+
+    /**
+     * It should log a warning if the media does not have a thumbnail
+     */
+    public function testSubscriberNoThumbnailLog()
+    {
+        $this->setupSubscriber(
+            123,
+            'image/jpeg',
+            321
+        );
+
+        $this->mediaManager->addFormatsAndUrl(Argument::any())->will(function ($args) {
+            $mediaApi = $args[0];
+            $mediaApi->setFormats(array(
+                'for' => '/fo',
+            ));
+        });
+
+        $this->document->setImageUrl(null)->shouldBeCalled();
+        $this->document->addField($this->field1->reveal())->shouldBeCalled();
+        $this->document->addField($this->field2->reveal())->shouldBeCalled();
+        $this->document->addField($this->field3->reveal())->shouldBeCalled();
+        $this->logger->warning(Argument::any())->shouldBeCalled();
+
+        $this->subscriber->handlePreIndex($this->event->reveal());
+    }
+
+    /**
+     * It should set the image URL to NULL if the media is not in the list of medias with
+     * thumbnails.
+     */
+    public function testSubscriberNotImage()
+    {
+        $this->setupSubscriber(
+            123,
+            'video/mpeg',
+            321
+        );
+
+        $this->mediaManager->addFormatsAndUrl(Argument::any())->will(function ($args) {
+            $mediaApi = $args[0];
+            $mediaApi->setFormats(array());
+        });
+
+        $this->document->setImageUrl(Argument::any())->shouldNotBeCalled();
+        $this->document->addField($this->field1->reveal())->shouldBeCalled();
+        $this->document->addField($this->field2->reveal())->shouldBeCalled();
+        $this->document->addField($this->field3->reveal())->shouldBeCalled();
+
+        $this->logger->warning(Argument::any())->shouldNotBeCalled();
+
+        $this->subscriber->handlePreIndex($this->event->reveal());
+    }
+
+    private function setupSubscriber($mediaId, $mediaMime, $collectionId)
+    {
+        $this->reflection->isSubclassOf(FileVersionMeta::class)->willReturn(true);
+        $this->metadata->getName()->willReturn(FileVersionMeta::class);
+        $this->event->getSubject()->willReturn($this->fileVersionMeta->reveal());
+        $this->fileVersionMeta->getLocale()->willReturn('de');
+        $this->media->getId()->willReturn($mediaId);
+        $this->media->getCollection()->willReturn($this->collection->reveal());
+        $this->collection->getId()->willReturn($collectionId);
+        $this->fileVersion->getMimeType()->willReturn($mediaMime);
+        $this->factory->createField('media_id', $mediaId)->willReturn($this->field1->reveal());
+        $this->factory->createField('media_mime', $mediaMime)->willReturn($this->field2->reveal());
+        $this->factory->createField('collection_id', $collectionId)->willReturn($this->field3->reveal());
     }
 }


### PR DESCRIPTION
It makes no sense to try and determine an image URL for a video, pdf or office document (at least not yet).

This PR changes the media search indexer to only determine the image URL for medias whose mime type starts with `image`.

Fixes: #1089
