### PR TITLE
Fixed document namespace

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -8,7 +8,7 @@
 
         <parameter key="sulu_core.webspace.cache_class">WebspaceCollectionCache</parameter>
         <parameter key="sulu_core.webspace.base_class">WebspaceCollection</parameter>
-        <parameter key="sulu_core.webspace.document_manager.webspace_initializer.class">Sulu\Component\Webspace\DocumentManager\WebspaceInitializer</parameter>
+        <parameter key="sulu_core.webspace.document_manager.webspace_initializer.class">Sulu\Component\Webspace\Document\Initializer\WebspaceInitializer</parameter>
     </parameters>
 
     <services>

--- a/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
+++ b/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sulu\Component\Webspace\DocumentManager;
+namespace Sulu\Component\Webspace\Document\Initializer;
 
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;


### PR DESCRIPTION
Fixes the namespace for the initializer in the webspace bundle.

Anything relating to the document manager should be in `Document/` namespace. Documents should be directly in this namespace `Document/FooDocument` and other things should be in sub namespaces, such as `Document\Initializer`, `Document\Subsciber` etc.