### PR TITLE
Refactoring "Content" to "Subscriber"

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
@@ -11,7 +11,7 @@
 namespace Sulu\Bundle\ContentBundle\Document;
 
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
-use Sulu\Component\Content\Document\Behavior\LocalizedContentBehavior;
+use Sulu\Component\Content\Document\Behavior\LocalizedStructureBehavior;
 use Sulu\Component\Content\Document\Behavior\NavigationContextBehavior;
 use Sulu\Component\Content\Document\Behavior\OrderBehavior;
 use Sulu\Component\Content\Document\Behavior\RedirectTypeBehavior;
@@ -40,7 +40,7 @@ class BasePageDocument implements
     TimestampBehavior,
     BlameBehavior,
     ParentBehavior,
-    LocalizedContentBehavior,
+    LocalizedStructureBehavior,
     ResourceSegmentBehavior,
     NavigationContextBehavior,
     RedirectTypeBehavior,

--- a/src/Sulu/Bundle/ContentBundle/Form/Type/AbstractStructureBehaviorType.php
+++ b/src/Sulu/Bundle/ContentBundle/Form/Type/AbstractStructureBehaviorType.php
@@ -19,9 +19,9 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Forms extending this class handle documents which implement
- * the ContentBehavior.
+ * the StructureBehavior.
  */
-abstract class AbstractContentBehaviorType extends AbstractType
+abstract class AbstractStructureBehaviorType extends AbstractType
 {
     /**
      * {@inheritDoc}

--- a/src/Sulu/Bundle/ContentBundle/Form/Type/BasePageDocumentType.php
+++ b/src/Sulu/Bundle/ContentBundle/Form/Type/BasePageDocumentType.php
@@ -18,7 +18,7 @@ use Sulu\Component\DocumentManager\DocumentManager;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 
-abstract class BasePageDocumentType extends AbstractContentBehaviorType
+abstract class BasePageDocumentType extends AbstractStructureBehaviorType
 {
     /**
      * @var SessionManagerInterface

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
@@ -6,7 +6,7 @@
     <services>
 
         <!-- Subscribers -->
-        <service id="sulu_content.document.subscriber.content" class="Sulu\Component\Content\Document\Subscriber\ContentSubscriber">
+        <service id="sulu_content.document.subscriber.content" class="Sulu\Component\Content\Document\Subscriber\StructureSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />
             <argument type="service" id="sulu.content.type_manager" />
             <argument type="service" id="sulu_document_manager.document_inspector" />
@@ -98,7 +98,7 @@
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
-        <service id="sulu_document_manager.subscriber.behavior.remove_content" class="Sulu\Component\Content\Document\Subscriber\ContentRemoveSubscriber">
+        <service id="sulu_document_manager.subscriber.behavior.remove_content" class="Sulu\Component\Content\Document\Subscriber\StructureRemoveSubscriber">
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu_document_manager.metadata_factory" />

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -21,8 +21,8 @@ use Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface;
 use Metadata\Driver\AdvancedDriverInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
 use Sulu\Component\Content\Document\ContentInstanceFactory;
@@ -30,6 +30,9 @@ use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
+use Sulu\Component\Content\Structure\Block;
+use Sulu\Component\Content\Structure\Factory\StructureFactory;
+use Sulu\Component\Content\Structure\Property;
 use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
@@ -88,7 +91,7 @@ class StructureProvider implements ProviderInterface
      */
     public function getMetadataForObject($object)
     {
-        if (!$object instanceof ContentBehavior) {
+        if (!$object instanceof StructureBehavior) {
             return;
         }
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -5,7 +5,7 @@ namespace Sulu\Bundle\DocumentManagerBundle\Bridge;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;
 use Sulu\Component\DocumentManager\DocumentInspector as BaseDocumentInspector;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
@@ -75,7 +75,7 @@ class DocumentInspector extends BaseDocumentInspector
      *
      * @return string
      */
-    public function getContentPath(ContentBehavior $document)
+    public function getContentPath(StructureBehavior $document)
     {
         $path = $this->getPath($document);
         $webspaceKey = $this->getWebspace($document);
@@ -93,13 +93,13 @@ class DocumentInspector extends BaseDocumentInspector
     }
 
     /**
-     * Return the structure for the given ContentBehavior implementing document
+     * Return the structure for the given StructureBehavior implementing document
      *
-     * @param ContentBehavior $document
+     * @param StructureBehavior $document
      *
      * @return StructureMetadata
      */
-    public function getStructure(ContentBehavior $document)
+    public function getStructure(StructureBehavior $document)
     {
         return $this->structureFactory->getStructure(
             $this->getMetadata($document)->getAlias(),
@@ -157,11 +157,11 @@ class DocumentInspector extends BaseDocumentInspector
     /**
      * Return the concrete localizations for the given document
      *
-     * @param ContentBehavior $document
+     * @param StructureBehavior $document
      *
      * @return array
      */
-    public function getLocales(ContentBehavior $document)
+    public function getLocales(StructureBehavior $document)
     {
         $locales = array();
         $node = $this->getNode($document);

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -11,7 +11,7 @@ use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
-use Sulu\Component\Content\Document\Subscriber\ContentSubscriber;
+use Sulu\Component\Content\Document\Subscriber\StructureSubscriber;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
 use Sulu\Component\Content\Document\Subscriber\ShadowLocaleSubscriber;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/PropertyEncoder.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/PropertyEncoder.php
@@ -9,7 +9,7 @@ use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
-use Sulu\Component\Content\Document\Subscriber\ContentSubscriber;
+use Sulu\Component\Content\Document\Subscriber\StructureSubscriber;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\DocumentManager\PropertyEncoder as BasePropertyEncoder;
 use Sulu\Component\Content\Metadata\PropertyMetadata;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/PropertyEncoder.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/PropertyEncoder.php
@@ -5,7 +5,7 @@ namespace Sulu\Bundle\DocumentManagerBundle\Bridge;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;
 use Sulu\Component\DocumentManager\DocumentInspector as BaseDocumentInspector;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Sulu\Component\DocumentManager\NamespaceRegistry;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentInspectorTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentInspectorTest.php
@@ -18,7 +18,8 @@ use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Structure\Factory\StructureFactoryInterface;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 use PHPCR\PropertyInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -79,12 +80,12 @@ class DocumentInspectorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should return the Structure for a document implementing ContentBehavior
+     * It should return the Structure for a document implementing StructureBehavior
      */
     public function testGetStructure()
     {
         $structure = new \stdClass;
-        $document = $this->prophesize(ContentBehavior::class);
+        $document = $this->prophesize(StructureBehavior::class);
         $document->getStructureType()->willReturn('foo');
 
         $this->metadataFactory->getMetadataForClass(get_class($document->reveal()))->willReturn($this->metadata->reveal());
@@ -116,7 +117,7 @@ class DocumentInspectorTest extends \PHPUnit_Framework_TestCase
             $properties[] = $property;
         }
 
-        $document = $this->prophesize(ContentBehavior::class);
+        $document = $this->prophesize(StructureBehavior::class);
         $this->documentRegistry->getNodeForDocument($document)->willReturn($this->node->reveal());
         $this->namespaceRegistry->getPrefix('system_localized')->willReturn('foo');
         $this->node->getProperties()->willReturn($properties);

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
@@ -14,8 +14,7 @@ use Massive\Bundle\SearchBundle\Search\Event\PreIndexEvent;
 use Massive\Bundle\SearchBundle\Search\SearchEvents;
 use Sulu\Bundle\MediaBundle\Content\MediaSelectionContainer;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
-use Sulu\Component\Content\MetadataInterface;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -81,7 +80,7 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
         $subject = $e->getSubject();
         $evaluator = $e->getFieldEvaluator();
 
-        if (false === $metadata->getClassMetadata()->reflection->isSubclassOf(ContentBehavior::class)) {
+        if (false === $metadata->getClassMetadata()->reflection->isSubclassOf(StructureBehavior::class)) {
             return;
         }
 

--- a/src/Sulu/Bundle/SearchBundle/EventListener/ContentSubscriber.php
+++ b/src/Sulu/Bundle/SearchBundle/EventListener/ContentSubscriber.php
@@ -17,7 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\ContentInstanceFactory;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
@@ -73,7 +73,7 @@ class ContentSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
 
-        if (!$document instanceof ContentBehavior) {
+        if (!$document instanceof StructureBehavior) {
             return;
         }
 
@@ -89,7 +89,7 @@ class ContentSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
 
-        if (!$document instanceof ContentBehavior) {
+        if (!$document instanceof StructureBehavior) {
             return;
         }
 

--- a/src/Sulu/Bundle/SearchBundle/EventListener/StructureSubscriber.php
+++ b/src/Sulu/Bundle/SearchBundle/EventListener/StructureSubscriber.php
@@ -25,7 +25,7 @@ use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 /**
  * Listen to sulu node save event and index the document
  */
-class ContentSubscriber implements EventSubscriberInterface
+class StructureSubscriber implements EventSubscriberInterface
 {
     /**
      * @var SearchManagerInterface

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -7,7 +7,7 @@
         <parameter key="sulu_search.controller.search.class">Sulu\Bundle\SearchBundle\Controller\SearchController</parameter>
         <parameter key="sulu_search.search.factory.class">Sulu\Bundle\SearchBundle\Search\Factory</parameter>
         <parameter key="sulu_search.admin.class">Sulu\Bundle\SearchBundle\Admin\SuluSearchAdmin</parameter>
-        <parameter key="sulu_search.event_subscriber.content.class">Sulu\Bundle\SearchBundle\EventListener\ContentSubscriber</parameter>
+        <parameter key="sulu_search.event_subscriber.content.class">Sulu\Bundle\SearchBundle\EventListener\StructureSubscriber</parameter>
     </parameters>
 
     <services>

--- a/src/Sulu/Bundle/SnippetBundle/Document/SnippetDocument.php
+++ b/src/Sulu/Bundle/SnippetBundle/Document/SnippetDocument.php
@@ -2,7 +2,7 @@
 
 namespace Sulu\Bundle\SnippetBundle\Document;
 
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureTypeFilingBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
 use Sulu\Component\Content\Document\Property\PropertyContainer;
@@ -23,7 +23,7 @@ class SnippetDocument implements
     BlameBehavior,
     AutoNameBehavior,
     StructureTypeFilingBehavior,
-    ContentBehavior,
+    StructureBehavior,
     WorkflowStageBehavior,
     UuidBehavior,
     PathBehavior

--- a/src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
+++ b/src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
@@ -5,9 +5,9 @@ namespace Sulu\Bundle\SnippetBundle\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Sulu\Bundle\ContentBundle\Form\Type\AbstractContentBehaviorType;
+use Sulu\Bundle\ContentBundle\Form\Type\AbstractStructureBehaviorType;
 
-class SnippetType extends AbstractContentBehaviorType
+class SnippetType extends AbstractStructureBehaviorType
 {
     /**
      * {@inheritDoc}

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -2,33 +2,32 @@
 
 namespace Sulu\Component\Content\Compat\Structure;
 
-use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Content\Compat\Structure as LegacyStructure;
-use Sulu\Component\Content\Compat\Property;
-use Sulu\Component\Content\Compat\PropertyTag;
-use Sulu\Component\Content\Section\SectionProperty;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Block\BlockProperty;
 use Sulu\Component\Content\Block\BlockPropertyType;
+use Sulu\Component\Content\Compat\Property;
+use Sulu\Component\Content\Compat\PropertyTag;
+use Sulu\Component\Content\Compat\Structure as LegacyStructure;
+use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureType;
-
+use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
+use Sulu\Component\Content\Document\Behavior\NavigationContextBehavior;
 use Sulu\Component\Content\Document\Behavior\RedirectTypeBehavior;
+use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
 use Sulu\Component\Content\Document\ContentDocumentInterface;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 use Sulu\Component\Content\Metadata\ItemMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata as NewProperty;
 use Sulu\Component\Content\Metadata\SectionMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
-use Sulu\Component\Content\Metadata\BlockMetadata;
-use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
-use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
-use Sulu\Component\Content\Document\Behavior\NavigationContextBehavior;
+use Sulu\Component\Content\Section\SectionProperty;
 
 class StructureBridge implements StructureInterface
 {
@@ -84,7 +83,7 @@ class StructureBridge implements StructureInterface
     /**
      * @param ContentDocumentInterface $document
      */
-    public function setDocument(ContentBehavior $document)
+    public function setDocument(StructureBehavior $document)
     {
         $this->document = $document;
     }
@@ -652,7 +651,7 @@ class StructureBridge implements StructureInterface
         return $this->document;
     }
 
-    protected function documentToStructure(ContentBehavior $document)
+    protected function documentToStructure(StructureBehavior $document)
     {
         return new $this($this->inspector->getStructure($document), $this->inspector, $this->propertyFactory, $document);
     }

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -28,6 +28,7 @@ use Sulu\Component\Content\Metadata\PropertyMetadata as NewProperty;
 use Sulu\Component\Content\Metadata\SectionMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\Content\Section\SectionProperty;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 
 class StructureBridge implements StructureInterface
 {

--- a/src/Sulu/Component/Content/Document/Behavior/ExtensionBehavior.php
+++ b/src/Sulu/Component/Content/Document/Behavior/ExtensionBehavior.php
@@ -6,7 +6,7 @@ namespace Sulu\Component\Content\Document\Behavior;
  * Documents implementing this behavior can have extensions applied to their
  * content.
  */
-interface ExtensionBehavior extends ContentBehavior
+interface ExtensionBehavior extends StructureBehavior
 {
     /**
      * Reutrn all extension data.

--- a/src/Sulu/Component/Content/Document/Behavior/LocalizedStructureBehavior.php
+++ b/src/Sulu/Component/Content/Document/Behavior/LocalizedStructureBehavior.php
@@ -17,6 +17,6 @@ use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
  * content documents implementing this behavior can change the 
  * structure type for each localization.
  */
-interface LocalizedContentBehavior
+interface LocalizedStructureBehavior
 {
 }

--- a/src/Sulu/Component/Content/Document/Behavior/StructureBehavior.php
+++ b/src/Sulu/Component/Content/Document/Behavior/StructureBehavior.php
@@ -24,7 +24,7 @@ use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
  * $this->getContent()->getProperty('foo')->getValue();
  * ````
  */
-interface ContentBehavior extends LocaleBehavior
+interface StructureBehavior extends LocaleBehavior
 {
     /**
      * Return the type of the structure used for the content

--- a/src/Sulu/Component/Content/Document/Behavior/StructureTypeFilingBehavior.php
+++ b/src/Sulu/Component/Content/Document/Behavior/StructureTypeFilingBehavior.php
@@ -3,7 +3,7 @@
 namespace Sulu\Component\Content\Document\Behavior;
 
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 
 /**
  * Documents implementing this behavior can have extensions applied to their

--- a/src/Sulu/Component/Content/Document/Subscriber/Compat/MapperRemoveSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/Compat/MapperRemoveSubscriber.php
@@ -10,7 +10,7 @@
 
 namespace Sulu\Component\Content\Document\Subscriber\Compat;
 
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Mapper\Event\ContentNodeDeleteEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
@@ -114,7 +114,7 @@ class MapperRemoveSubscriber implements EventSubscriberInterface
 
     private function supports($document)
     {
-        return $document instanceof ContentBehavior;
+        return $document instanceof StructureBehavior;
     }
 
     private function getEvent($document)

--- a/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
@@ -15,7 +15,7 @@ use Sulu\Component\Content\Mapper\Translation\TranslatedProperty;
 use Sulu\Component\Content\Compat\Structure\Property;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\DocumentManager\DocumentInspector;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -85,9 +85,9 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
 
-        // we currently only support fallback on ContentBehavior implementors
+        // we currently only support fallback on StructureBehavior implementors
         // because we use the template key to determine localization status
-        if (!$document instanceof ContentBehavior) {
+        if (!$document instanceof StructureBehavior) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
@@ -118,7 +118,7 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
      */
     public function getAvailableLocalization(NodeInterface $node, $document, $locale)
     {
-        $structureTypeName = $this->encoder->localizedSystemName(ContentSubscriber::STRUCTURE_TYPE_FIELD, $locale);
+        $structureTypeName = $this->encoder->localizedSystemName(StructureSubscriber::STRUCTURE_TYPE_FIELD, $locale);
 
         // check if it already is the correct localization
         if ($node->hasProperty($structureTypeName)) {
@@ -277,6 +277,6 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
 
     private function getPropertyName($locale)
     {
-        return $this->encoder->localizedSystemName(ContentSubscriber::STRUCTURE_TYPE_FIELD, $locale);
+        return $this->encoder->localizedSystemName(StructureSubscriber::STRUCTURE_TYPE_FIELD, $locale);
     }
 }

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureRemoveSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureRemoveSubscriber.php
@@ -8,7 +8,7 @@ use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
@@ -16,7 +16,7 @@ use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 /**
  * Remove routes and references associated with content
  */
-class ContentRemoveSubscriber implements EventSubscriberInterface
+class StructureRemoveSubscriber implements EventSubscriberInterface
 {
     private $inspector;
     private $documentManager;
@@ -44,7 +44,7 @@ class ContentRemoveSubscriber implements EventSubscriberInterface
         $document = $event->getDocument();
 
         // TODO: This is not a good indicator. There should be a RoutableBehavior here.
-        if (!$document instanceof ContentBehavior) {
+        if (!$document instanceof StructureBehavior) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -14,7 +14,7 @@ use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Symfony\Component\EventDispatcher\Event;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface as DocumentMetadataFactory;
@@ -26,13 +26,13 @@ use Sulu\Component\Content\Document\Property\Property;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
-use Sulu\Component\Content\Document\Behavior\LocalizedContentBehavior;
+use Sulu\Component\Content\Document\Behavior\LocalizedStructureBehavior;
 use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Exception\MandatoryPropertyException;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 
-class ContentSubscriber extends AbstractMappingSubscriber
+class StructureSubscriber extends AbstractMappingSubscriber
 {
     const STRUCTURE_TYPE_FIELD = 'template';
 
@@ -95,7 +95,7 @@ class ContentSubscriber extends AbstractMappingSubscriber
      */
     protected function supports($document)
     {
-        return $document instanceof ContentBehavior;
+        return $document instanceof StructureBehavior;
     }
 
     /**
@@ -178,7 +178,7 @@ class ContentSubscriber extends AbstractMappingSubscriber
 
     private function getStructureTypePropertyName($document, $locale)
     {
-        if ($document instanceof LocalizedContentBehavior) {
+        if ($document instanceof LocalizedStructureBehavior) {
             return $this->encoder->localizedSystemName(self::STRUCTURE_TYPE_FIELD, $locale);
         }
 

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -31,7 +31,7 @@ use Sulu\Component\Content\Compat\StructureType;
 use Sulu\Component\Content\ContentTypeInterface;
 use Sulu\Component\Content\ContentTypeManager;
 use Sulu\Component\Content\ContentTypeManagerInterface;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
@@ -217,9 +217,9 @@ class ContentMapper implements ContentMapperInterface
             $document = $this->documentManager->create($documentAlias);
         }
 
-        if (!$document instanceof ContentBehavior) {
+        if (!$document instanceof StructureBehavior) {
             throw new \RuntimeException(sprintf(
-                'The content mapper can only be used to save documents implementing the ContentBehavior interface, got: "%s"',
+                'The content mapper can only be used to save documents implementing the StructureBehavior interface, got: "%s"',
                 get_class($document)
             ));
         }
@@ -556,7 +556,7 @@ class ContentMapper implements ContentMapperInterface
         $document = $this->inspector->getParent($document);
         $documentDepth = $this->inspector->getDepth($document);
 
-        while ($document instanceof ContentBehavior && $documentDepth >= $contentDepth) {
+        while ($document instanceof StructureBehavior && $documentDepth >= $contentDepth) {
             $documents[] = $document;
 
             $document = $this->inspector->getParent($document);
@@ -1211,7 +1211,7 @@ class ContentMapper implements ContentMapperInterface
     {
         $collection = array();
         foreach ($documents as $document) {
-            if (!$document instanceof ContentBehavior) {
+            if (!$document instanceof StructureBehavior) {
                 continue;
             }
 

--- a/tests/Sulu/Component/Content/Document/Property/ManagedPropertyContainerTest.php
+++ b/tests/Sulu/Component/Content/Document/Property/ManagedPropertyContainerTest.php
@@ -16,6 +16,7 @@ use Sulu\Component\Content\Document\Property\PropertyContainer;
 use Sulu\Component\Content\Document\Property\PropertyValue;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 
 class ManagedPropertyContainerTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,7 +25,7 @@ class ManagedPropertyContainerTest extends \PHPUnit_Framework_TestCase
         $this->contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
         $this->node = $this->prophesize(NodeInterface::class);
         $this->structure = $this->prophesize(StructureMetadata::class);
-        $this->document = $this->prophesize(ContentBehavior::class);
+        $this->document = $this->prophesize(StructureBehavior::class);
         $this->contentType = $this->prophesize(ContentTypeInterface::class);
         $this->encoder = $this->prophesize(PropertyEncoder::class);
         $this->structureProperty = $this->prophesize(PropertyMetadata::class);

--- a/tests/Sulu/Component/Content/Document/Subscriber/ContentSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/ContentSubscriberTest.php
@@ -14,7 +14,7 @@ use PHPCR\NodeInterface;
 use Prophecy\Argument;
 use Sulu\Component\Content\ContentTypeInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Property\PropertyContainer;
 use Sulu\Component\Content\Document\Subscriber\ContentSubscriber;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
@@ -175,7 +175,7 @@ class ContentSubscriberTest extends SubscriberTestCase
 
 }
 
-class TestContentDocument implements ContentBehavior
+class TestContentDocument implements StructureBehavior
 {
     private $structureType;
     private $content;

--- a/tests/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriberTest.php
@@ -2,7 +2,7 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -24,7 +24,7 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->inspector = $this->prophesize(DocumentInspector::class);
         $this->registry = $this->prophesize(DocumentRegistry::class);
 
-        $this->document = $this->prophesize(ContentBehavior::class)->willImplement(WebspaceBehavior::class);
+        $this->document = $this->prophesize(StructureBehavior::class)->willImplement(WebspaceBehavior::class);
         $this->webspace = $this->prophesize(Webspace::class);
         $this->localization1 = $this->prophesize(Localization::class);
         $this->localization2 = $this->prophesize(Localization::class);
@@ -47,7 +47,7 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
     }
 
     /**
-     * It should return early if not implementing ContentBehavior
+     * It should return early if not implementing StructureBehavior
      */
     public function testReturnEarly()
     {

--- a/tests/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriberTest.php
@@ -40,7 +40,7 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->hydrateEvent->getDocument()->willReturn($this->document->reveal());
         $this->hydrateEvent->getLocale()->willReturn(self::FIX_LOCALE);
         $this->encoder->localizedSystemName(
-            ContentSubscriber::STRUCTURE_TYPE_FIELD, self::FIX_LOCALE
+            StructureSubscriber::STRUCTURE_TYPE_FIELD, self::FIX_LOCALE
         )->willReturn(self::FIX_PROPERTY_NAME);
         $this->webspaceManager->findWebspaceByKey(self::FIX_WEBSPACE)->willReturn($this->webspace);
         $this->registry->getDefaultLocale()->willReturn('de');
@@ -117,10 +117,10 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->webspace->getLocalization(self::FIX_LOCALE)->willReturn($this->localization1->reveal());
         $this->localization1->getLocalization()->willReturn('en');
         $this->localization2->getLocalization()->willReturn('at');
-        $this->encoder->localizedSystemName(ContentSubscriber::STRUCTURE_TYPE_FIELD, 'en')->willReturn('prop1');
+        $this->encoder->localizedSystemName(StructureSubscriber::STRUCTURE_TYPE_FIELD, 'en')->willReturn('prop1');
         $this->node->hasProperty('prop1')->willReturn(false);
         $this->localization1->getParent()->willReturn($this->localization2->reveal());
-        $this->encoder->localizedSystemName(ContentSubscriber::STRUCTURE_TYPE_FIELD, 'at')->willReturn('prop2');
+        $this->encoder->localizedSystemName(StructureSubscriber::STRUCTURE_TYPE_FIELD, 'at')->willReturn('prop2');
         $this->node->hasProperty('prop2')->willReturn(true);
         $this->hydrateEvent->getOption('hydrate.load_ghost_content', true)->willReturn(true);
 
@@ -145,9 +145,9 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->localization1->getLocalization()->willReturn('en');
         $this->localization2->getLocalization()->willReturn('at');
 
-        $this->encoder->localizedSystemName(ContentSubscriber::STRUCTURE_TYPE_FIELD, 'en')->willReturn('prop1');
+        $this->encoder->localizedSystemName(StructureSubscriber::STRUCTURE_TYPE_FIELD, 'en')->willReturn('prop1');
         $this->node->hasProperty('prop1')->willReturn(false);
-        $this->encoder->localizedSystemName(ContentSubscriber::STRUCTURE_TYPE_FIELD, 'at')->willReturn('prop2');
+        $this->encoder->localizedSystemName(StructureSubscriber::STRUCTURE_TYPE_FIELD, 'at')->willReturn('prop2');
         $this->node->hasProperty('prop2')->willReturn(true);
         $this->hydrateEvent->getOption('hydrate.load_ghost_content', true)->willReturn(true);
 
@@ -177,9 +177,9 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->localization1->getLocalization()->willReturn('en');
         $this->localization2->getLocalization()->willReturn('at');
 
-        $this->encoder->localizedSystemName(ContentSubscriber::STRUCTURE_TYPE_FIELD, 'en')->willReturn('prop1');
+        $this->encoder->localizedSystemName(StructureSubscriber::STRUCTURE_TYPE_FIELD, 'en')->willReturn('prop1');
         $this->node->hasProperty('prop1')->willReturn(false);
-        $this->encoder->localizedSystemName(ContentSubscriber::STRUCTURE_TYPE_FIELD, 'at')->willReturn('prop2');
+        $this->encoder->localizedSystemName(StructureSubscriber::STRUCTURE_TYPE_FIELD, 'at')->willReturn('prop2');
         $this->node->hasProperty('prop2')->willReturn(true);
         $this->hydrateEvent->getOption('hydrate.load_ghost_content', true)->willReturn(true);
 

--- a/tests/Sulu/Component/Content/Document/Subscriber/StructureSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/StructureSubscriberTest.php
@@ -16,10 +16,10 @@ use Sulu\Component\Content\ContentTypeInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Property\PropertyContainer;
-use Sulu\Component\Content\Document\Subscriber\ContentSubscriber;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
+use Sulu\Component\Content\Document\Subscriber\StructureSubscriber;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
@@ -30,7 +30,7 @@ use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\Mapper\Translation\TranslatedProperty;
 use Sulu\Component\Content\Document\Property\PropertyValue;
 
-class ContentSubscriberTest extends SubscriberTestCase
+class StructureSubscriberTest extends SubscriberTestCase
 {
     public function setUp()
     {
@@ -46,7 +46,7 @@ class ContentSubscriberTest extends SubscriberTestCase
         $this->propertyFactory = $this->prophesize(LegacyPropertyFactory::class);
         $this->inspector = $this->prophesize(DocumentInspector::class);
 
-        $this->subscriber = new ContentSubscriber(
+        $this->subscriber = new StructureSubscriber(
             $this->encoder->reveal(),
             $this->contentTypeManager->reveal(),
             $this->inspector->reveal(),

--- a/tests/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriberTest.php
@@ -2,7 +2,7 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
-use Sulu\Component\Content\Document\Behavior\ContentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;


### PR DESCRIPTION
This PR will change all references to `Content` in class names to `Structure`.

The term `Content` is generally not used, and will be removed from the Glossary.