### PR TITLE
Renamed structure methods

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -125,7 +125,7 @@ class StructureProvider implements ProviderInterface
         $indexMeta->setCategoryName($categoryName);
         $indexMeta->setIndexName($indexName);
 
-        foreach ($structure->getModelProperties() as $property) {
+        foreach ($structure->getProperties() as $property) {
             if ($property instanceof BlockMetadata) {
                 $propertyMapping = new ComplexMetadata();
                 foreach ($property->getComponents() as $component) {

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -553,7 +553,7 @@ class StructureBridge implements StructureInterface
      */
     public function getLocalizedTitle($languageCode)
     {
-        return $this->structure->getLocalizedTitle($languageCode);
+        return $this->structure->getTitle($languageCode);
     }
 
     /**

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -245,7 +245,7 @@ class StructureBridge implements StructureInterface
     public function getProperties($flatten = false)
     {
         if ($flatten) {
-            $items = $this->structure->getModelProperties();
+            $items = $this->structure->getProperties();
         } else {
             $items = $this->structure->getChildren();
         }

--- a/src/Sulu/Component/Content/Document/Property/ManagedPropertyContainer.php
+++ b/src/Sulu/Component/Content/Document/Property/ManagedPropertyContainer.php
@@ -67,7 +67,7 @@ class ManagedPropertyContainer extends PropertyContainer
             $this->node = $this->inspector->getNode($this->document);
         }
 
-        $structureProperty = $this->structure->getModelProperty($name);
+        $structureProperty = $this->structure->getProperty($name);
 
         $contentTypeName = $structureProperty->getType();
 
@@ -115,7 +115,7 @@ class ManagedPropertyContainer extends PropertyContainer
     {
         $this->init();
         $values = array();
-        foreach (array_keys($this->structure->getModelProperties()) as $childName) {
+        foreach (array_keys($this->structure->getProperties()) as $childName) {
             $values[$childName] = $this->normalize($this->getProperty($childName)->getValue());
         }
 
@@ -133,7 +133,7 @@ class ManagedPropertyContainer extends PropertyContainer
 
     public function bind($data, $clearMissing = true)
     {
-        foreach ($this->structure->getModelProperties() as $childName => $child) {
+        foreach ($this->structure->getProperties() as $childName => $child) {
             if (false === $clearMissing && !isset($data[$childName])) {
                 continue;
             }

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -212,7 +212,7 @@ class StructureSubscriber extends AbstractMappingSubscriber
         $webspaceName = $this->inspector->getWebspace($document);
         $structure = $this->inspector->getStructure($document);
 
-        foreach ($structure->getModelProperties() as $propertyName => $structureProperty) {
+        foreach ($structure->getProperties() as $propertyName => $structureProperty) {
             $realProperty = $propertyContainer->getProperty($propertyName);
             $value = $realProperty->getValue();
 

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -64,9 +64,7 @@ use Sulu\Bundle\ContentBundle\Document\HomeDocument;
 /**
  * Maps content nodes to phpcr nodes with content types and provides utility function to handle content nodes.
  *
- * Short term todo:
- *
- * - Rename localization, languageCode, language etc. to "locale"
+ * @deprecated since 1.0-? use the DocumentManager instead.
  */
 class ContentMapper implements ContentMapperInterface
 {

--- a/src/Sulu/Component/Content/Metadata/BlockMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/BlockMetadata.php
@@ -20,13 +20,8 @@ class BlockMetadata extends PropertyMetadata
     public $components = array();
     public $defaultComponentName;
 
-    public function getType() 
-    {
-        return 'block';
-    }
-
     /**
-     * Return the default type name
+     * Return the default component name
      *
      * @return string
      */
@@ -37,14 +32,21 @@ class BlockMetadata extends PropertyMetadata
 
     /**
      * Return the components
+     *
+     * @return ComponentMetadata[]
      */
     public function getComponents() 
     {
         return $this->components;
     }
 
-    public function addComponent(ComponentMetadata $item)
+    /**
+     * Add a new component
+     *
+     * @param ComponentMetadata $component
+     */
+    public function addComponent(ComponentMetadata $component)
     {
-        $this->components[] = $item;
+        $this->components[] = $component;
     }
 }

--- a/src/Sulu/Component/Content/Metadata/ComponentMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ComponentMetadata.php
@@ -3,9 +3,9 @@
 namespace Sulu\Component\Content\Metadata;
 
 /**
- * Represents only a collection of properties
+ * Represents only a collection of properties.
  *
- * Used in blocks
+ * Used in blocks.
  */
 class ComponentMetadata extends ItemMetadata
 {

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -38,7 +38,13 @@ abstract class ItemMetadata
     public $description = array();
 
     /**
-     * Tags, e.g. [['name' => 'sulu_search.field', 'type' => 'string']]
+     * Tags, e.g. 
+     *
+     * ````
+     * array(
+     *     array('name' => 'sulu_search.field', 'type' => 'string')
+     * )
+     * ````
      *
      * @var array
      */
@@ -47,11 +53,11 @@ abstract class ItemMetadata
     /**
      * Parameters applying to the property
      *
-     * e.g.
-     *
-     * {
-     *     placeholder: Enter some text
+     * ````
+     * array(
+     *     'placeholder' => 'Enter some text',
      * }
+     * ````
      *
      * @var array
      */
@@ -86,7 +92,8 @@ abstract class ItemMetadata
     /**
      * Return the named property
      *
-     * @return string $name
+     * @param string $name
+     * @return ItemMetadata
      */
     public function getChild($name)
     {
@@ -105,6 +112,7 @@ abstract class ItemMetadata
      * if it does not.
      *
      * @param string $name
+     * @return bool
      */
     public function hasChild($name)
     {
@@ -114,7 +122,7 @@ abstract class ItemMetadata
     /**
      * Adds a child item
      *
-     * @param Item $child
+     * @param ItemMetadata $child
      */
     public function addChild(ItemMetadata $child)
     {
@@ -139,14 +147,14 @@ abstract class ItemMetadata
     }
 
     /**
-     * Return the localized name of this Item or
+     * Return the localized name of this ItemMetadata or
      * default to the name.
      *
      * @param string $locale Localization
      *
      * @return string
      */
-    public function getLocalizedTitle($locale)
+    public function getTitle($locale)
     {
         if (isset($this->title[$locale])) {
             return $this->title[$locale];
@@ -155,6 +163,12 @@ abstract class ItemMetadata
         return ucfirst($this->name);
     }
 
+    /**
+     * Return the paramter with the given name.
+     *
+     * @param string $name
+     * @return mixed
+     */
     public function getParameter($name)
     {
         if (!isset($this->parameters[$name])) {
@@ -168,17 +182,9 @@ abstract class ItemMetadata
     }
 
     /**
-     * TODO: Rename to getParameters
+     * Return the name of this item
      *
-     * {@inheritDoc}
-     */
-    public function getParams() 
-    {
-        return $this->parameters;
-    }
-
-    /**
-     * {@inheritDoc}
+     * @return string
      */
     public function getName()
     {
@@ -186,7 +192,9 @@ abstract class ItemMetadata
     }
 
     /**
-     * {@inheritDoc}
+     * Return the tags of this item.
+     *
+     * @return array
      */
     public function getTags() 
     {
@@ -194,7 +202,11 @@ abstract class ItemMetadata
     }
 
     /**
-     * {@inheritDoc}
+     * Return the named tag
+     *
+     * @param string $tagName
+     * @throws \InvalidArgumentException
+     * @return array
      */
     public function getTag($tagName)
     {
@@ -203,8 +215,18 @@ abstract class ItemMetadata
                 return $tag;
             }
         }
+
+        throw new \InvalidArgumentException(sprintf(
+            'Unknown tag "%s"', $tagName
+        ));
     }
 
+    /**
+     * Return true if this item has the named tag.
+     *
+     * @param string $name
+     * @return bool
+     */
     public function hasTag($name)
     {
         foreach ($this->tags as $tag) {
@@ -217,24 +239,20 @@ abstract class ItemMetadata
     }
 
     /**
-     * TODO: This is duplicated
-     * @deprecated
-     *
-     * {@inheritDoc}
-     */
-    public function getTitle($locale) 
-    {
-        return $this->getLocalizedTitle($locale);
-    }
-
-    /**
      * Return the parameters for this property
+     *
+     * @return array
      */
     public function getParameters() 
     {
         return $this->parameters;
     }
 
+    /**
+     * Return the decsription of this property
+     *
+     * @return string
+     */
     public function getDescription() 
     {
         return $this->description;

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
@@ -50,7 +50,7 @@ class XmlLoader extends XmlLegacyLoader
             $structure->children[$propertyName] = $this->createProperty($propertyName, $dataProperty);
         }
 
-        $structure->burnModelRepresentation();
+        $structure->burnProperties();
 
         return $structure;
     }

--- a/src/Sulu/Component/Content/Metadata/PropertyMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/PropertyMetadata.php
@@ -11,6 +11,9 @@
 
 namespace Sulu\Component\Content\Metadata;
 
+/**
+ * Metadata for a property. Contains both UI and model metadata.
+ */
 class PropertyMetadata extends ItemMetadata
 {
     /**

--- a/src/Sulu/Component/Content/Metadata/SectionMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/SectionMetadata.php
@@ -11,6 +11,10 @@
 
 namespace Sulu\Component\Content\Metadata;
 
+/**
+ * Metadata for a section. A section is a UI component which
+ * groups a bunch of properties.
+ */
 class SectionMetadata extends ItemMetadata
 {
     /**
@@ -20,6 +24,11 @@ class SectionMetadata extends ItemMetadata
      */
     public $colSpan = null;
 
+    /**
+     * Return the colspan.
+     *
+     * @return integer
+     */
     public function getColSpan() 
     {
         return $this->colSpan;

--- a/src/Sulu/Component/Content/Metadata/StructureMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/StructureMetadata.php
@@ -47,7 +47,7 @@ class StructureMetadata extends ItemMetadata
 
     /**
      * Same as ItemMetadata::$children but without Sections
-     * @see StructureMetadata::burnModelRepresentation()
+     * @see StructureMetadata::burnProperties()
      * @var array
      */
     public $properties;
@@ -87,13 +87,16 @@ class StructureMetadata extends ItemMetadata
     }
 
     /**
-     * Populate the $modelProperties property with only those propertires
+     * Populate the $properties property with only those propertires
      * which are not related to the UI (i.e. the sections).
      *
+     * The data is therefore duplicated, but this does not matter as we
+     * only create this data once.
+     *
      * This should be called once after creating the structure and (therefore
-     * before writing to the cache
+     * before writing to the cache).
      */
-    public function burnModelRepresentation()
+    public function burnProperties()
     {
         $properties = array();
         foreach ($this->children as $child) {

--- a/tests/Sulu/Component/Content/Document/Property/ManagedPropertyContainerTest.php
+++ b/tests/Sulu/Component/Content/Document/Property/ManagedPropertyContainerTest.php
@@ -89,7 +89,7 @@ class ManagedPropertyContainerTest extends \PHPUnit_Framework_TestCase
     private function doGetProperty($name, $contentTypeName, $locale)
     {
         $this->structureProperty->getType()->willReturn($contentTypeName);
-        $this->structure->getModelProperty($name)->willReturn($this->structureProperty);
+        $this->structure->getProperty($name)->willReturn($this->structureProperty);
         $this->contentTypeManager->get($contentTypeName)->willReturn($this->contentType->reveal());
 
         if ($locale) {

--- a/tests/Sulu/Component/Content/Document/Subscriber/StructureSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/StructureSubscriberTest.php
@@ -92,7 +92,7 @@ class StructureSubscriberTest extends SubscriberTestCase
         // map the content
         $this->inspector->getStructure($document)->willReturn($this->structure->reveal());
         $this->inspector->getWebspace($document)->willReturn('webspace');
-        $this->structure->getModelProperties()->willReturn(array(
+        $this->structure->getProperties()->willReturn(array(
             'prop1' => $this->structureProperty->reveal()
         ));
         $this->structureProperty->isRequired()->willReturn(true);
@@ -131,7 +131,7 @@ class StructureSubscriberTest extends SubscriberTestCase
         // map the content
         $this->inspector->getStructure($document)->willReturn($this->structure->reveal());
         $this->inspector->getWebspace($document)->willReturn('webspace');
-        $this->structure->getModelProperties()->willReturn(array(
+        $this->structure->getProperties()->willReturn(array(
             'prop1' => $this->structureProperty->reveal()
         ));
         $this->structureProperty->isRequired()->willReturn(true);

--- a/tests/Sulu/Component/Content/Metadata/ItemMetadataCase.php
+++ b/tests/Sulu/Component/Content/Metadata/ItemMetadataCase.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Sulu\Component\Content\Metadata;
+
+use Sulu\Component\Content\Metadata\ItemMetadata;
+
+abstract class ItemMetadataCase extends \PHPUnit_Framework_TestCase
+{
+    abstract public function getMetadata();
+
+    /**
+     * It should throw an exception if the named tag does not exist.
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testGetTagNotExist()
+    {
+        $metadata = $this->getMetadata();
+        $metadata->getTag('foo');
+    }
+
+    /**
+     * It should get a named tag
+     */
+    public function testGetTag()
+    {
+        $metadata = $this->getMetadata();
+        $tag = array('name' => 'foo');
+        $metadata->tags = array($tag);
+        $this->assertEquals($tag, $metadata->getTag('foo'));
+    }
+
+    /**
+     * It should return a localized title
+     */
+    public function testGetTitle()
+    {
+        $metadata = $this->getMetadata();
+        $metadata->title['fr'] = 'Foobar';
+        $this->assertEquals('Foobar', $metadata->getTitle('fr'));
+    }
+
+    /**
+     * It should return the name if the localized title does not exist
+     */
+    public function testGetTitleNoLocalization()
+    {
+        $metadata = $this->getMetadata();
+        $metadata->name = 'foobar';
+        $this->assertEquals('Foobar', $metadata->getTitle('es'));
+    }
+
+    /**
+     * It get a parameter
+     */
+    public function testGetParameters()
+    {
+        $metadata = $this->getMetadata();
+        $metadata->parameters = array(
+            'param1' => 'param',
+        );
+        $this->assertEquals('param', $metadata->getParameter('param1'));
+    }
+
+    /**
+     * It throws an exception if the parameter does not exist
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Unknown parameter "param5", known parameters: "param1"
+     */
+    public function testGetParametersInvalid()
+    {
+        $metadata = $this->getMetadata();
+        $metadata->parameters = array(
+            'param1' => 'param',
+        );
+        $metadata->getParameter('param5');
+    }
+}

--- a/tests/Sulu/Component/Content/Metadata/StructureMetdataTest.php
+++ b/tests/Sulu/Component/Content/Metadata/StructureMetdataTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sulu\Component\Content\Metadata;
+
+use Sulu\Component\Content\Metadata\StructureMetadata;
+
+class StructureMetdataTest extends ItemMetadataCase
+{
+    public function getMetadata()
+    {
+        return new StructureMetadata();
+    }
+}


### PR DESCRIPTION
This PR changes the API for `Structure`:

- `getModelProperties` => `getProperties`.
- `getProperties(true)` => `getProperties`. get properties now always returns only non-UI children. `->getChildren` can be used to get everything including Sections.