### PR TITLE
Fixes unique navigation id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * BUGFIX      #1191 [AdminBundle]    Fixed unique Navigation ID
+
 * 1.0.0 (2015-07-01)
     * ENHANCEMENT #1319 [ContentBundle]  Fixed location of cached structures
     * BUGFIX      #1316 [ContentBundle]  Reenabled csrf protection and disabled it only for the content mapper

--- a/src/Sulu/Bundle/AdminBundle/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Navigation/NavigationItem.php
@@ -542,7 +542,7 @@ class NavigationItem implements \Iterator
             'eventArguments' => $this->getEventArguments(),
             'hasSettings' => $this->getHasSettings(),
             'disabled' => $this->getDisabled(),
-            'id' => ($this->getId() != null) ? $this->getId() : uniqid(), //FIXME don't use uniqid()
+            'id' => ($this->getId() != null) ? $this->getId() : str_replace('.', '', uniqid('', true)), //FIXME don't use uniqid()
         );
 
         if ($this->getHeaderIcon() != null || $this->getHeaderTitle() != null) {


### PR DESCRIPTION
Currently this is only a quickfix, i would prefer delete the ID from the API and handle it better in the frontend?

__Tasks:__

- [ ] test coverage
- [ ] gather feedback for my changes
- [x] added changelog line


__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | none
| Fixed tickets | fixes https://github.com/sulu-io/sulu-standard/issues/472
| BC Breaks     | none
| Doc           | none