### PR TITLE
URL of shadow pages are not delivered in the urls array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG for Sulu
     * BUGFIX      #1211 [WebsiteBundle]  Fixed merge of test-page childs into upper layer in website navigation
     * ENHANCMENT  #1206 [SecurityBundle] Corrected translation for roles entry in navigation
     * BUGFIX      #1203 [AdminBundle]    Fixed routes for tabs
+    * BUGFIX      #1199 [ContentBundle]  URL of shadow pages are not delivered in the urls array
     * BUGFIX      #1169 [AdminBundle]    Fixed sidebar issue (prepending div instead of appending)
     * ENHANCEMENT #1159 [SecurityBundle] Change role naming to keep symfony2 conventions.
     * BUGFIX      #1156 [MediaBundle]    Fix mimetype check for ghostscript

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -1640,13 +1640,13 @@ class ContentMapper implements ContentMapperInterface
         $contentType = $this->contentTypeManager->get($property->getContentTypeName());
 
         foreach ($webspace->getAllLocalizations() as $localization) {
-
             // prepare translation vars
             $locale = $localization->getLocalization();
+            $shadowLocale = $this->getShadowLocale($node, $localization->getLocalization());
             $translatedProperty = new TranslatedProperty($property, $locale, $this->languageNamespace);
 
             // state property
-            $propertyTranslator = $this->createPropertyTranslator($localization);
+            $propertyTranslator = $this->createPropertyTranslator($shadowLocale);
             $statePropertyName = $propertyTranslator->getName('state');
 
             if ($node->getPropertyValueWithDefault(

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -1301,7 +1301,6 @@ class ContentMapper implements ContentMapperInterface
         $structureType = $this->nodeHelper->getStructureTypeForNode($contentNode) ?: Structure::TYPE_PAGE;
         $propertyTranslator = $this->createPropertyTranslator($localization, $structureType);
 
-        // START: getAvailableLocalization
         if ($this->stopwatch) {
             $this->stopwatch->start('contentManager.loadByNode');
             $this->stopwatch->start('contentManager.loadByNode.available-localization');
@@ -1334,7 +1333,6 @@ class ContentMapper implements ContentMapperInterface
         );
 
         $availableLocalization = $this->getResolvedLocale($contentNode, $availableLocalization);
-        // END: getAvailableLocalization
 
         if (($excludeGhost && $excludeShadow) && $availableLocalization != $localization) {
             return;

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -1333,7 +1333,7 @@ class ContentMapper implements ContentMapperInterface
             false
         );
 
-        $availableLocalization = $this->getShadowLocale($contentNode, $availableLocalization);
+        $availableLocalization = $this->getResolvedLocale($contentNode, $availableLocalization);
         // END: getAvailableLocalization
 
         if (($excludeGhost && $excludeShadow) && $availableLocalization != $localization) {
@@ -1473,7 +1473,7 @@ class ContentMapper implements ContentMapperInterface
     /**
      * Determites locale for shadow-pages.
      */
-    private function getShadowLocale(NodeInterface $node, $defaultLocale)
+    private function getResolvedLocale(NodeInterface $node, $defaultLocale)
     {
         $propertyTranslator = $this->createPropertyTranslator($defaultLocale);
         $shadowOn = $node->getPropertyValueWithDefault($propertyTranslator->getName('shadow-on'), false);
@@ -1642,11 +1642,11 @@ class ContentMapper implements ContentMapperInterface
         foreach ($webspace->getAllLocalizations() as $localization) {
             // prepare translation vars
             $locale = $localization->getLocalization();
-            $shadowLocale = $this->getShadowLocale($node, $localization->getLocalization());
+            $resolvedLocale = $this->getResolvedLocale($node, $localization->getLocalization());
             $translatedProperty = new TranslatedProperty($property, $locale, $this->languageNamespace);
 
             // state property
-            $propertyTranslator = $this->createPropertyTranslator($shadowLocale);
+            $propertyTranslator = $this->createPropertyTranslator($resolvedLocale);
             $statePropertyName = $propertyTranslator->getName('state');
 
             if ($node->getPropertyValueWithDefault(
@@ -2235,7 +2235,7 @@ class ContentMapper implements ContentMapperInterface
             }
 
             $originLocale = $locale;
-            $locale = $this->getShadowLocale($node, $locale);
+            $locale = $this->getResolvedLocale($node, $locale);
             $propertyTranslator->setLanguage($locale);
 
             // load default data

--- a/tests/Sulu/Component/Content/Mapper/ContentMapperTest.php
+++ b/tests/Sulu/Component/Content/Mapper/ContentMapperTest.php
@@ -3526,6 +3526,60 @@ class ContentMapperTest extends PhpcrTestCase
         $this->assertArrayNotHasKey('es', $urls);
     }
 
+    public function testGetResourceLocatorsWithShadow()
+    {
+        $data = array(
+            array('title' => 'Beschreibung', 'url' => '/beschreibung'),
+            array('title' => 'Description', 'url' => '/description'),
+        );
+        $node = $this->mapper->save(
+            $data[0],
+            'overview',
+            'default',
+            'de',
+            1,
+            true,
+            null,
+            null,
+            Structure::STATE_PUBLISHED
+        );
+        $this->mapper->save(
+            $data[1],
+            'overview',
+            'default',
+            'en',
+            1,
+            true,
+            $node->getUuid(),
+            null,
+            Structure::STATE_TEST
+        );
+        $this->mapper->save(
+            $data[1],
+            'overview',
+            'default',
+            'en',
+            1,
+            true,
+            $node->getUuid(),
+            null,
+            Structure::STATE_TEST,
+            true,
+            'de'
+        );
+
+        $content = $this->mapper->load($node->getUuid(), 'default', 'en');
+        $urls = $content->getUrls();
+
+        $this->assertArrayHasKey('en', $urls);
+        $this->assertEquals('/description', $urls['en']);
+        $this->assertArrayNotHasKey('en_us', $urls);
+        $this->assertArrayHasKey('de', $urls);
+        $this->assertEquals('/beschreibung', $urls['de']);
+        $this->assertArrayNotHasKey('de_at', $urls);
+        $this->assertArrayNotHasKey('es', $urls);
+    }
+
     public function testContentTypeSwitch()
     {
         try {


### PR DESCRIPTION
if you have a shadow page the url for that in the language switcher on the webpage.

__tasks:__

- [x] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none