### PR TITLE
Feature/refactoring content data

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
@@ -125,6 +125,7 @@ class ExcerptStructureExtension extends AbstractExtension
                 $languageCode,
                 null // segmentkey
             );
+
             $data[$property->getName()] = $property->getValue();
         }
 

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -226,7 +226,11 @@ class StructureBridge implements StructureInterface
      */
     public function getProperty($name)
     {
-        $property = $this->structure->getChild($name);
+        if ($this->hasProperty($name)) {
+            $property = $this->structure->getProperty($name);
+        } else {
+            $property = $this->structure->getChild($name);
+        }
 
         return $this->createLegacyPropertyFromItem($property);
     }
@@ -236,7 +240,7 @@ class StructureBridge implements StructureInterface
      */
     public function hasProperty($name)
     {
-        return $this->structure->hasChild($name);
+        return $this->structure->hasProperty($name);
     }
 
     /**

--- a/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
+++ b/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
@@ -29,6 +29,8 @@ class ManagedStructure extends Structure
     private $inspector;
     private $structure;
     private $node;
+    private $legacyProperties = array();
+    private $contentViewProperties = array();
 
     /**
      * @param ContentTypeManagerInterface $contentTypeManager
@@ -77,6 +79,8 @@ class ManagedStructure extends Structure
             $property = $this->legacyPropertyFactory->createProperty($structureProperty);
         }
 
+        $this->legacyProperties[$name] = $property;
+
         $bridge = new StructureBridge($this->structure, $this->inspector, $this->legacyPropertyFactory, $this->document);
         $property->setStructure($bridge);
 
@@ -93,6 +97,28 @@ class ManagedStructure extends Structure
         $this->properties[$name] = $valueProperty;
 
         return $valueProperty;
+    }
+
+    public function getContentViewProperty($name)
+    {
+        if (isset($this->contentViewProperties[$name])) {
+            return $this->contentViewProperties[$name];
+        }
+
+        // initialize the legacy property
+        $this->getProperty($name);
+        $legacyProperty = $this->legacyProperties[$name];
+
+        $structureProperty = $this->structure->getProperty($name);
+        $contentTypeName = $structureProperty->getType();
+        $contentType = $this->contentTypeManager->get($contentTypeName);
+        $propertyValue = new PropertyValue(
+            $name,
+            $contentType->getContentData($legacyProperty)
+        );
+        $this->contentViewProperties[$name] = $propertyValue;
+
+        return $propertyValue;
     }
 
     /**

--- a/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
+++ b/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
@@ -52,9 +52,7 @@ class ManagedStructure extends Structure
     }
 
     /**
-     * Return the named property and evaluate its content
-     *
-     * @param string $name
+     * {@inheritDoc}
      */
     public function getProperty($name)
     {
@@ -99,6 +97,9 @@ class ManagedStructure extends Structure
         return $valueProperty;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getContentViewProperty($name)
     {
         if (isset($this->contentViewProperties[$name])) {

--- a/src/Sulu/Component/Content/Document/Structure/PropertyValue.php
+++ b/src/Sulu/Component/Content/Document/Structure/PropertyValue.php
@@ -1,5 +1,6 @@
 <?php
 
+
 namespace Sulu\Component\Content\Document\Structure;
 
 /**

--- a/src/Sulu/Component/Content/Document/Structure/Structure.php
+++ b/src/Sulu/Component/Content/Document/Structure/Structure.php
@@ -75,6 +75,14 @@ class Structure implements StructureInterface
     /**
      * {@inheritDoc}
      */
+    public function getContentViewProperty($name)
+    {
+        throw new \Exception('Cannot retrieve content view property for non-managed property');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function hasProperty($name)
     {
         return $this->offsetExists($name);

--- a/src/Sulu/Component/Content/Document/Structure/StructureInterface.php
+++ b/src/Sulu/Component/Content/Document/Structure/StructureInterface.php
@@ -23,8 +23,20 @@ interface StructureInterface extends \ArrayAccess
      * Return the named property
      *
      * @param string $name
+     *
+     * @return PropertyValue
      */
     public function getProperty($name);
+
+    /**
+     * Return the named property as rendered by the content type
+     * ->getContentData() method.
+     *
+     * @param string $name
+     *
+     * @return PropertyValue
+     */
+    public function getContentViewProperty($name);
 
     /**
      * Return true if the container has the named property

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -1042,7 +1042,7 @@ class ContentMapper implements ContentMapperInterface
      */
     private function getPropertyData($document, LegacyProperty $property)
     {
-        return $document->getStructure()->getProperty($property->getName())->getValue();
+        return $document->getStructure()->getContentViewProperty($property->getName())->getValue();
     }
 
     /**


### PR DESCRIPTION
Added method to `Structure` to render the `ContentData` which is required by the content mapper when hydrating rows.