### PR TITLE
Improved speed for media list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * ENHANCEMENT #1251 [SecurityBundle] Refactored PasswordResetting controller for better reusability
+    * BUGFIX      #1253 [MediaBundle]    Improved speed for media list query
     * ENHANCEMENT #1234 [All]            Prefix twig extension functions with "sulu_"
     * ENHANCEMENT #1237 [AdminBundle]    Fixed typos in behat tests
     * BUGFIX      #1235 [ContentBundle]  Fixed delete page which has children with history url

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
@@ -10,6 +10,8 @@
 
 namespace Sulu\Bundle\MediaBundle\Entity;
 
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 
 /**
@@ -53,4 +55,16 @@ interface MediaRepositoryInterface
      * @return mixed
      */
     public function findMediaByCollectionId($collectionId, $limit, $offset);
+
+    /**
+     * Returns amount of affected rows
+     *
+     * @param array $filter
+     *
+     * @return int
+     *
+     * @throws NoResultException
+     * @throws NonUniqueResultException
+     */
+    public function count(array $filter);
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -381,7 +381,8 @@ class MediaManager implements MediaManagerInterface
     {
         $media = array();
         $mediaEntities = $this->mediaRepository->findMedia($filter, $limit, $offset);
-        $this->count = $mediaEntities instanceof Paginator ? $mediaEntities->count() : count($mediaEntities);
+        $this->count = $this->mediaRepository->count($filter);
+
         foreach ($mediaEntities as $mediaEntity) {
             $media[] = $this->addFormatsAndUrl(new Media($mediaEntity, $locale, null));
         }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionMeta.orm.xml
@@ -3,6 +3,11 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Sulu\Bundle\MediaBundle\Entity\CollectionMeta" table="me_collection_meta">
+        <indexes>
+            <index columns="title"/>
+            <index columns="locale"/>
+        </indexes>
+
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/File.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/File.orm.xml
@@ -4,11 +4,14 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <entity name="Sulu\Bundle\MediaBundle\Entity\File" table="me_files" repository-class="Sulu\Bundle\MediaBundle\Entity\FileRepository">
+        <indexes>
+            <index columns="version"/>
+        </indexes>
 
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="version" type="integer" column="version" />
+        <field name="version" type="integer" column="version"/>
         <one-to-many field="fileVersions" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" mapped-by="file">
             <cascade>
                 <cascade-persist />

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
@@ -4,6 +4,9 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <entity name="Sulu\Bundle\MediaBundle\Entity\FileVersion" table="me_file_versions">
+        <indexes>
+            <index columns="version"/>
+        </indexes>
 
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
@@ -3,6 +3,11 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Sulu\Bundle\MediaBundle\Entity\FileVersionMeta" table="me_file_version_meta">
+        <indexes>
+            <index columns="title"/>
+            <index columns="locale"/>
+        </indexes>
+
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Media.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Media.orm.xml
@@ -6,8 +6,6 @@
     <entity name="Sulu\Bundle\MediaBundle\Entity\Media" table="me_media" repository-class="Sulu\Bundle\MediaBundle\Entity\MediaRepository">
         <indexes>
             <index columns="changed"/>
-            <index columns="idCollections"/>
-            <index columns="idMediaTypes"/>
         </indexes>
 
         <id name="id" type="integer" column="id">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Media.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Media.orm.xml
@@ -4,6 +4,11 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <entity name="Sulu\Bundle\MediaBundle\Entity\Media" table="me_media" repository-class="Sulu\Bundle\MediaBundle\Entity\MediaRepository">
+        <indexes>
+            <index columns="changed"/>
+            <index columns="idCollections"/>
+            <index columns="idMediaTypes"/>
+        </indexes>
 
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/MediaType.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/MediaType.orm.xml
@@ -3,6 +3,10 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Sulu\Bundle\MediaBundle\Entity\MediaType" table="me_media_types">
+        <indexes>
+            <index columns="name"/>
+        </indexes>
+
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -1,0 +1,345 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Functional\Entity;
+
+use Doctrine\ORM\EntityManager;
+use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
+use Sulu\Bundle\MediaBundle\Entity\CollectionType;
+use Sulu\Bundle\MediaBundle\Entity\File;
+use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Entity\MediaRepository;
+use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\TagBundle\Entity\Tag;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class MediaRepositoryTest extends SuluTestCase
+{
+    /**
+     * @var EntityManager
+     */
+    private $em;
+
+    /**
+     * @var Collection
+     */
+    private $collection;
+
+    /**
+     * @var MediaType[]
+     */
+    private $mediaTypes = array();
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->purgeDatabase();
+        $this->em = $this->db('ORM')->getOm();
+        $this->setUpCollection();
+        $this->setUpMedia();
+    }
+
+    protected function setUpMedia()
+    {
+        // Create Media Type
+        $documentType = new MediaType();
+        $documentType->setName('document');
+        $documentType->setDescription('This is a document');
+
+        $imageType = new MediaType();
+        $imageType->setName('image');
+        $imageType->setDescription('This is an image');
+
+        $videoType = new MediaType();
+        $videoType->setName('video');
+        $videoType->setDescription('This is a video');
+
+        $this->mediaTypes['image'] = $imageType;
+        $this->mediaTypes['video'] = $videoType;
+
+        // create some tags
+        $tag1 = new Tag();
+        $tag1->setName('Tag 1');
+
+        $tag2 = new Tag();
+        $tag2->setName('Tag 2');
+
+        $this->em->persist($tag1);
+        $this->em->persist($tag2);
+        $this->em->persist($documentType);
+        $this->em->persist($imageType);
+        $this->em->persist($videoType);
+
+        $this->em->flush();
+    }
+
+    protected function setUpCollection()
+    {
+        $collection = new Collection();
+        $style = array(
+            'type' => 'circle',
+            'color' => '#ffcc00',
+        );
+
+        $collection->setStyle(json_encode($style));
+
+        // Create Collection Type
+        $collectionType = new CollectionType();
+        $collectionType->setName('Default Collection Type');
+        $collectionType->setDescription('Default Collection Type');
+
+        $collection->setType($collectionType);
+
+        // Collection Meta 1
+        $collectionMeta = new CollectionMeta();
+        $collectionMeta->setTitle('Test Collection');
+        $collectionMeta->setDescription('This Description is only for testing');
+        $collectionMeta->setLocale('en-gb');
+        $collectionMeta->setCollection($collection);
+
+        $collection->addMeta($collectionMeta);
+
+        // Collection Meta 2
+        $collectionMeta2 = new CollectionMeta();
+        $collectionMeta2->setTitle('Test Kollektion');
+        $collectionMeta2->setDescription('Dies ist eine Test Beschreibung');
+        $collectionMeta2->setLocale('de');
+        $collectionMeta2->setCollection($collection);
+
+        $collection->addMeta($collectionMeta2);
+
+        $this->em->persist($collection);
+        $this->em->persist($collectionType);
+        $this->em->persist($collectionMeta);
+        $this->em->persist($collectionMeta2);
+
+        $this->collection = $collection;
+    }
+
+    protected function createMedia($name, $title, $type = 'image')
+    {
+        $media = new Media();
+        $media->setType($this->mediaTypes[$type]);
+
+        // create file
+        $file = new File();
+        $file->setVersion(1);
+        $file->setMedia($media);
+
+        // create file version
+        $fileVersion = new FileVersion();
+        $fileVersion->setVersion(1);
+        $fileVersion->setName($name . '.jpeg');
+        $fileVersion->setMimeType('image/jpg');
+        $fileVersion->setFile($file);
+        $fileVersion->setSize(1124214);
+        $fileVersion->setDownloadCounter(2);
+        $fileVersion->setChanged(new \DateTime('1937-04-20'));
+        $fileVersion->setCreated(new \DateTime('1937-04-20'));
+        $fileVersion->setStorageOptions('{"segment":"1","fileName":"' . $name . '.jpeg"}');
+        if (!file_exists(__DIR__ . '/../../uploads/media/1')) {
+            mkdir(__DIR__ . '/../../uploads/media/1', 0777, true);
+        }
+        copy($this->getImagePath(), __DIR__ . '/../../uploads/media/1/' . $name . '.jpeg');
+
+        // create meta
+        $fileVersionMeta = new FileVersionMeta();
+        $fileVersionMeta->setLocale('en-gb');
+        $fileVersionMeta->setTitle($title);
+        $fileVersionMeta->setDescription('decription');
+        $fileVersionMeta->setFileVersion($fileVersion);
+
+        $fileVersion->addMeta($fileVersionMeta);
+        $fileVersion->setDefaultMeta($fileVersionMeta);
+
+        $file->addFileVersion($fileVersion);
+
+        $media->addFile($file);
+        $media->setCollection($this->collection);
+
+        $this->em->persist($media);
+        $this->em->persist($file);
+        $this->em->persist($fileVersionMeta);
+        $this->em->persist($fileVersion);
+
+        $this->em->flush();
+
+        return $media;
+    }
+
+    /**
+     * @return string
+     */
+    private function getImagePath()
+    {
+        return __DIR__ . '/../../app/Resources/images/photo.jpeg';
+    }
+
+    public function testFindMedia()
+    {
+        $media1 = $this->createMedia('test-1', 'test-1');
+        $media2 = $this->createMedia('test-2', 'test-2');
+        $media3 = $this->createMedia('test-3', 'test-3');
+        $media4 = $this->createMedia('test-4', 'test-4');
+
+        /** @var MediaRepository $mediaRepository */
+        $mediaRepository = $this->getContainer()->get('sulu_media.media_repository');
+
+        $result = $mediaRepository->findMedia();
+
+        $this->assertCount(4, $result);
+        $this->assertEquals($media1->getId(), $result[0]->getId());
+        $this->assertEquals($media2->getId(), $result[1]->getId());
+        $this->assertEquals($media3->getId(), $result[2]->getId());
+        $this->assertEquals($media4->getId(), $result[3]->getId());
+    }
+
+    public function testFindMediaPagination()
+    {
+        $media1 = $this->createMedia('test-1', 'test-1');
+        $media2 = $this->createMedia('test-2', 'test-2');
+        $media3 = $this->createMedia('test-3', 'test-3');
+        $media4 = $this->createMedia('test-4', 'test-4');
+
+        /** @var MediaRepository $mediaRepository */
+        $mediaRepository = $this->getContainer()->get('sulu_media.media_repository');
+
+        $result = $mediaRepository->findMedia(array(), 3, 0);
+
+        $this->assertCount(3, $result);
+        $this->assertEquals($media1->getId(), $result[0]->getId());
+        $this->assertEquals($media2->getId(), $result[1]->getId());
+        $this->assertEquals($media3->getId(), $result[2]->getId());
+
+        $result = $mediaRepository->findMedia(array(), 3, 3);
+        $this->assertCount(1, $result);
+        $this->assertEquals($media4->getId(), $result[0]->getId());
+
+        $result = $mediaRepository->findMedia(array(), 3, 6);
+        $this->assertCount(0, $result);
+
+        $this->assertEquals(4, $mediaRepository->count(array()));
+    }
+
+    public function testFindMediaSearch()
+    {
+        $media1 = $this->createMedia('test-1', 'A');
+        $media2 = $this->createMedia('test-2', 'AA');
+        $media3 = $this->createMedia('test-3', 'AAA');
+        $media4 = $this->createMedia('test-4', 'AB');
+
+        /** @var MediaRepository $mediaRepository */
+        $mediaRepository = $this->getContainer()->get('sulu_media.media_repository');
+
+        $result = $mediaRepository->findMedia(array('search' => 'AA'));
+
+        $this->assertCount(2, $result);
+        $this->assertEquals($media2->getId(), $result[0]->getId());
+        $this->assertEquals($media3->getId(), $result[1]->getId());
+
+        $this->assertEquals(2, $mediaRepository->count(array('search' => 'AA')));
+    }
+
+    public function testFindMediaSearchPagination()
+    {
+        $media1 = $this->createMedia('test-1', 'A');
+        $media2 = $this->createMedia('test-2', 'AA');
+        $media3 = $this->createMedia('test-3', 'AAA');
+        $media4 = $this->createMedia('test-4', 'AAAA');
+
+        /** @var MediaRepository $mediaRepository */
+        $mediaRepository = $this->getContainer()->get('sulu_media.media_repository');
+
+        $result = $mediaRepository->findMedia(array('search' => 'AA'), 2, 0);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals($media2->getId(), $result[0]->getId());
+        $this->assertEquals($media3->getId(), $result[1]->getId());
+
+        $result = $mediaRepository->findMedia(array('search' => 'AA'), 2, 2);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($media4->getId(), $result[0]->getId());
+
+        $this->assertEquals(3, $mediaRepository->count(array('search' => 'AA')));
+    }
+
+    public function testFindMediaTypes()
+    {
+        $media1 = $this->createMedia('test-1', 'test-1', 'video');
+        $media2 = $this->createMedia('test-2', 'test-2', 'image');
+        $media3 = $this->createMedia('test-3', 'test-3', 'video');
+        $media4 = $this->createMedia('test-4', 'test-4', 'image');
+
+        /** @var MediaRepository $mediaRepository */
+        $mediaRepository = $this->getContainer()->get('sulu_media.media_repository');
+
+        $result = $mediaRepository->findMedia(array('types' => array('video')));
+
+        $this->assertCount(2, $result);
+        $this->assertEquals($media1->getId(), $result[0]->getId());
+        $this->assertEquals($media3->getId(), $result[1]->getId());
+
+        $result = $mediaRepository->findMedia(array('types' => array('image')));
+
+        $this->assertCount(2, $result);
+        $this->assertEquals($media2->getId(), $result[0]->getId());
+        $this->assertEquals($media4->getId(), $result[1]->getId());
+
+        $result = $mediaRepository->findMedia(array('types' => array('image', 'video')));
+
+        $this->assertCount(4, $result);
+        $this->assertEquals($media1->getId(), $result[0]->getId());
+        $this->assertEquals($media2->getId(), $result[1]->getId());
+        $this->assertEquals($media3->getId(), $result[2]->getId());
+        $this->assertEquals($media4->getId(), $result[3]->getId());
+
+        $result = $mediaRepository->findMedia(array('types' => array('asdf')));
+
+        $this->assertCount(0, $result);
+
+        $this->assertEquals(2, $mediaRepository->count(array('types' => array('image'))));
+        $this->assertEquals(2, $mediaRepository->count(array('types' => array('video'))));
+        $this->assertEquals(4, $mediaRepository->count(array('types' => array('image', 'video'))));
+        $this->assertEquals(0, $mediaRepository->count(array('types' => array('asdf'))));
+    }
+
+    public function testFindMediaTypesPagination()
+    {
+        $media1 = $this->createMedia('test-1', 'test-1', 'video');
+        $media2 = $this->createMedia('test-2', 'test-2', 'video');
+        $media3 = $this->createMedia('test-3', 'test-3', 'video');
+        $media4 = $this->createMedia('test-4', 'test-4', 'image');
+
+        /** @var MediaRepository $mediaRepository */
+        $mediaRepository = $this->getContainer()->get('sulu_media.media_repository');
+
+        $result = $mediaRepository->findMedia(array('types' => array('video')), 2, 0);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals($media1->getId(), $result[0]->getId());
+        $this->assertEquals($media2->getId(), $result[1]->getId());
+
+        $result = $mediaRepository->findMedia(array('types' => array('video')), 2, 2);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($media3->getId(), $result[0]->getId());
+
+        $result = $mediaRepository->findMedia(array('types' => array('video')), 2, 4);
+
+        $this->assertCount(0, $result);
+
+        $this->assertEquals(3, $mediaRepository->count(array('types' => array('video'))));
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -342,4 +342,21 @@ class MediaRepositoryTest extends SuluTestCase
 
         $this->assertEquals(3, $mediaRepository->count(array('types' => array('video'))));
     }
+
+    public function testFindMediaByIds()
+    {
+        $media1 = $this->createMedia('test-1', 'test-1', 'video');
+        $media2 = $this->createMedia('test-2', 'test-2', 'video');
+        $media3 = $this->createMedia('test-3', 'test-3', 'video');
+        $media4 = $this->createMedia('test-4', 'test-4', 'image');
+
+        /** @var MediaRepository $mediaRepository */
+        $mediaRepository = $this->getContainer()->get('sulu_media.media_repository');
+
+        $result = $mediaRepository->findMedia(array('ids' => array($media1->getId(), $media3->getId())));
+
+        $this->assertCount(2, $result);
+        $this->assertEquals($media1->getId(), $result[0]->getId());
+        $this->assertEquals($media3->getId(), $result[1]->getId());
+    }
 }


### PR DESCRIPTION
Something like this would be the solution for the products issue (https://github.com/sulu-io/sulu/issues/1224) too.

__tasks:__

- [x] test coverage
- [ ] gather feedback for my changes
- [x] submit changes to the documentation

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none