### PR TITLE
Integrating metadata mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "willdurand/hateoas-bundle": "0.3.*",
         "symfony/swiftmailer-bundle": "~2.3",
         "pagerfanta/pagerfanta": "~1.0",
-        "sulu/document-manager": "dev-master",
-        "sulu/document-manager": "dev-master"
+        "sulu/document-manager": "dev-metadata-event"
     },
     "require-dev": {
         "phpcr/phpcr-shell": "~1.0.0@alpha",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "willdurand/hateoas-bundle": "0.3.*",
         "symfony/swiftmailer-bundle": "~2.3",
         "pagerfanta/pagerfanta": "~1.0",
-        "sulu/document-manager": "dev-metadata-event"
+        "sulu/document-manager": "dev-develop"
     },
     "require-dev": {
         "phpcr/phpcr-shell": "~1.0.0@alpha",

--- a/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
@@ -305,6 +305,9 @@ class BasePageDocument implements
      */
     public function setRedirectType($redirectType)
     {
+        if ($redirectType === null) {
+            die('asd');
+        }
         $this->redirectType = $redirectType;
     }
 

--- a/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
@@ -154,6 +154,8 @@ class BasePageDocument implements
      */
     protected $locale;
 
+    protected $originalLocale;
+
     /**
      * @var ChildrenCollection
      */

--- a/src/Sulu/Bundle/ContentBundle/Form/Type/BasePageDocumentType.php
+++ b/src/Sulu/Bundle/ContentBundle/Form/Type/BasePageDocumentType.php
@@ -69,7 +69,7 @@ abstract class BasePageDocumentType extends AbstractStructureBehaviorType
             'allow_add' => true,
             'allow_delete' => true,
         ));
-        $builder->add('redirectType', 'text');
+        $builder->add('redirectType', 'integer');
         $builder->add('redirectTarget', 'document_object');
         $builder->add('redirectExternal', 'text');
         $builder->add('workflowStage', 'integer');

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
@@ -15,14 +15,10 @@
         </service>
 
         <service id="sulu_navigationContext.document.subscriber.navigation_context" class="Sulu\Component\Content\Document\Subscriber\NavigationContextSubscriber">
-            <argument type="service" id="sulu_document_manager.property_encoder" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_redirect_type.document.subscriber.redirect_type" class="Sulu\Component\Content\Document\Subscriber\RedirectTypeSubscriber">
-            <argument type="service" id="sulu_document_manager.property_encoder" />
-            <argument type="service" id="sulu_document_manager.proxy_factory" />
-            <argument type="service" id="sulu_document_manager.document_registry" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
@@ -72,7 +68,6 @@
         </service>
 
         <service id="sulu_document_manager.document.subscriber.order" class="Sulu\Component\Content\Document\Subscriber\OrderSubscriber">
-            <argument type="service" id="sulu_document_manager.property_encoder" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
@@ -83,9 +78,6 @@
         </service>
 
         <service id="sulu_document_manager.document.subscriber.route" class="Sulu\Component\Content\Document\Subscriber\RouteSubscriber">
-            <argument type="service" id="sulu_document_manager.property_encoder" />
-            <argument type="service" id="sulu_document_manager.proxy_factory" />
-            <argument type="service" id="sulu_document_manager.document_registry" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
@@ -63,58 +63,6 @@
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
-        <!-- Core Subscribers -->
-        <service id="sulu_document_manager.subscriber.core.instantiator" class="Sulu\Component\DocumentManager\Subscriber\Core\InstantiatorSubscriber">
-            <argument type="service" id="sulu_document_manager.metadata_factory" />
-            <tag name="sulu_document_manager.event_subscriber" />
-        </service>
-
-        <service id="sulu_document_manager.subscriber.core.registrator" class="Sulu\Component\DocumentManager\Subscriber\Core\RegistratorSubscriber">
-            <argument type="service" id="sulu_document_manager.document_registry" />
-            <tag name="sulu_document_manager.event_subscriber" />
-        </service>
-
-        <service id="sulu_document_manager.subscriber.phpcr.reorder" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\ReorderSubscriber">
-            <argument type="service" id="sulu_document_manager.node_manager" />
-            <argument type="service" id="sulu_document_manager.document_registry" />
-            <tag name="sulu_document_manager.event_subscriber" />
-        </service>
-
-        <!-- PHPCR subscribers -->
-        <service id="sulu_document_manager.subscriber.phpcr.find" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\FindSubscriber">
-            <argument type="service" id="sulu_document_manager.metadata_factory" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
-            <argument type="service" id="sulu_document_manager.event_dispatcher" />
-            <tag name="sulu_document_manager.event_subscriber" />
-        </service>
-
-        <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
-            <argument type="service" id="doctrine_phpcr.default_session" />
-            <argument type="service" id="sulu_document_manager.event_dispatcher" />
-            <tag name="sulu_document_manager.event_subscriber" />
-        </service>
-
-        <service id="sulu_document_manager.subscriber.phpcr.general" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber">
-            <argument type="service" id="sulu_document_manager.document_registry" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
-            <argument type="service" id="sulu_document_manager.event_dispatcher" />
-            <tag name="sulu_document_manager.event_subscriber" />
-        </service>
-
-        <service id="sulu_document_manager.subscriber.phpcr.remove" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\RemoveSubscriber">
-            <argument type="service" id="sulu_document_manager.document_registry" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
-            <tag name="sulu_document_manager.event_subscriber" />
-        </service>
-
-        <service id="sulu_document_manager.subscriber.core.mapping" class="Sulu\Component\DocumentManager\Subscriber\Core\MappingSubscriber">
-            <argument type="service" id="sulu_document_manager.metadata_factory" />
-            <argument type="service" id="sulu_document_manager.property_encoder" />
-            <argument type="service" id="sulu_document_manager.proxy_factory"/>
-            <argument type="service" id="sulu_document_manager.document_registry"/>
-            <tag name="sulu_document_manager.event_subscriber"/>
-        </service>
-
     </services>
 
 </container>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
@@ -23,7 +23,6 @@
         </service>
 
         <service id="sulu_document_manager.suscriber.behavior.blame" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Audit\BlameSubscriber">
-            <argument type="service" id="sulu_document_manager.property_encoder" />
             <argument type="service" id="security.token_storage" />
             <tag name="sulu_document_manager.event_subscriber" />
             <tag name="sulu.context" context="admin" />
@@ -106,6 +105,14 @@
             <argument type="service" id="sulu_document_manager.document_registry" />
             <argument type="service" id="sulu_document_manager.node_manager" />
             <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <service id="sulu_document_manager.subscriber.core.mapping" class="Sulu\Component\DocumentManager\Subscriber\Core\MappingSubscriber">
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+            <argument type="service" id="sulu_document_manager.property_encoder" />
+            <argument type="service" id="sulu_document_manager.proxy_factory"/>
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
         </service>
 
     </services>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -99,6 +99,69 @@
             <argument type="collection" />
         </service>
 
+        <!-- Query converer -->
+        <service id="sulu_document_manager.query.converter" class="Sulu\Component\Content\Document\Query\StructureQueryBuilderConverter">
+            <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+            <argument type="service" id="sulu_document_manager.property_encoder" />
+            <argument type="service" id="sulu_document_manager.document_strategy" />
+            <argument type="service" id="sulu_content.structure.factory" />
+        </service>
+
+        <!-- Core Subscribers -->
+        <service id="sulu_document_manager.subscriber.core.instantiator" class="Sulu\Component\DocumentManager\Subscriber\Core\InstantiatorSubscriber">
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <service id="sulu_document_manager.subscriber.core.registrator" class="Sulu\Component\DocumentManager\Subscriber\Core\RegistratorSubscriber">
+            <argument type="service" id="sulu_document_manager.document_registry" />
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.reorder" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\ReorderSubscriber">
+            <argument type="service" id="sulu_document_manager.node_manager" />
+            <argument type="service" id="sulu_document_manager.document_registry" />
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <!-- PHPCR subscribers -->
+        <service id="sulu_document_manager.subscriber.phpcr.find" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\FindSubscriber">
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+            <argument type="service" id="sulu_document_manager.node_manager" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
+            <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
+            <argument type="service" id="sulu_document_manager.query.converter" />
+            <argument>Sulu\Component\Content\Document\Query\QueryBuilder</argument>
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.general" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber">
+            <argument type="service" id="sulu_document_manager.document_registry" />
+            <argument type="service" id="sulu_document_manager.node_manager" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.remove" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\RemoveSubscriber">
+            <argument type="service" id="sulu_document_manager.document_registry" />
+            <argument type="service" id="sulu_document_manager.node_manager" />
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <service id="sulu_document_manager.subscriber.core.mapping" class="Sulu\Component\DocumentManager\Subscriber\Core\MappingSubscriber">
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+            <argument type="service" id="sulu_document_manager.property_encoder" />
+            <argument type="service" id="sulu_document_manager.proxy_factory"/>
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
     </services>
 
 </container>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -31,6 +31,7 @@
         </service>
 
         <service id="sulu_document_manager.metadata_factory.base" class="Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory" public="false">
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <argument>%sulu_document_manager.mapping%</argument>
         </service>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -285,7 +285,6 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->assertEquals('Products-2 en_us', $result[9]['title']);
         $this->assertEquals('Products-3 en_us', $result[10]['title']);
 
-        $this->assertEquals('/', $result[0]['url']);
         $this->assertEquals('/news', $result[1]['url']);
         $this->assertEquals('/news/news-1', $result[2]['url']);
         $this->assertEquals('/news/news-2', $result[3]['url']);
@@ -297,6 +296,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->assertEquals('http://www.asdf.at', $result[9]['url']);
         $this->assertEquals('/news', $result[10]['url']);
 
+        $this->assertEquals('/', $result[0]['url']);
         $this->assertEquals(1, $result[0]['nodeType']);
         $this->assertEquals(1, $result[1]['nodeType']);
         $this->assertEquals(1, $result[2]['nodeType']);

--- a/src/Sulu/Component/Content/Document/Query/QueryBuilder.php
+++ b/src/Sulu/Component/Content/Document/Query/QueryBuilder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Sulu\Component\Content\Document\Query;
+
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder as BaseQueryBuilder;
+
+class QueryBuilder extends BaseQueryBuilder
+{
+    /**
+     * @var array
+     */
+    private $structureMap;
+
+    /**
+     * Assign a structure to a document alias.
+     *
+     * This allows you to use structure fields in criteria as follows:
+     *
+     * ````
+     * $qb->from()->document('foo', 'p');
+     * $qb->useStructure('p', 'overview');
+     * $qb->where()->eq()->field('p.structure.field1')->literal('barbar');
+     * ````
+     *
+     * @param mixed $documentAlias Document alias to register structure to
+     * @param mixed $structureName Name of the structure to register.
+     * @throws InvalidArgumentException If a document with the given alias is already registered.
+     * @return $this
+     */
+    public function useStructure($documentAlias, $structureName)
+    {
+        if (isset($this->structureMap[$documentAlias])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Structure "%s" is already registered for document alias "%s". Trying to register structure "%s"',
+                $this->structureMap[$documentAlias],
+                $documentAlias,
+                $structureName
+            ));
+        }
+
+        $this->structureMap[$documentAlias] = $structureName;
+
+        return $this;
+    }
+
+    /**
+     * Return the document alias to structure name map.
+     *
+     * @return array
+     */
+    public function getStructureMap()
+    {
+        return $this->structureMap;
+    }
+}

--- a/src/Sulu/Component/Content/Document/Query/StructureQueryBuilderConverter.php
+++ b/src/Sulu/Component/Content/Document/Query/StructureQueryBuilderConverter.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Sulu\Component\Content\Document\Query;
+
+use Sulu\Component\DocumentManager\Query\QueryBuilderConverter;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder as BaseQueryBuilder;
+use Sulu\Component\Content\Document\Query\QueryBuilder;
+use PHPCR\SessionInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
+use Sulu\Component\DocumentManager\DocumentStrategyInterface;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
+
+class StructureQueryBuilderConverter extends QueryBuilderConverter
+{
+    private $structureMetaFactory;
+    private $structureMap = array();
+
+    /**
+     * @param SessionInterface $session
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param MetadataFactoryInterface $metadataFactory
+     * @param PropertyEncoder $encoder
+     */
+    public function __construct(
+        SessionInterface $session,
+        EventDispatcherInterface $eventDispatcher,
+        MetadataFactoryInterface $metadataFactory,
+        PropertyEncoder $encoder,
+        DocumentStrategyInterface $strategy,
+        StructureMetadataFactory $structureMetaFactory
+    ) {
+        parent::__construct($session, $eventDispatcher, $metadataFactory, $encoder, $strategy);
+        $this->structureMetaFactory = $structureMetaFactory;
+    }
+
+    public function getQuery(BaseQueryBuilder $queryBuilder)
+    {
+        if (!$queryBuilder instanceof QueryBuilder) {
+            throw new \BadMethodCallException(sprintf(
+                'StructureQueryBuilderConverter must be passed an instance of the Sulu\Component\Content\Document\Query\QueryBuilder, got "%s"',
+                get_class($queryBuilder)
+            ));
+        }
+
+        $this->structureMap = $queryBuilder->getStructureMap();
+        return parent::getQuery($queryBuilder);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getPhpcrProperty($alias, $field)
+    {
+        if (false !== $position = strpos($field, 'structure#')) {
+            $propertyName = substr($field, $position + 10);
+
+            if (!isset($this->structureMap[$alias])) {
+                throw new \InvalidArgumentException(sprintf(
+                    'No structure has been registered for document alias "%s". Use ->useStructure(\'%s\', \'structure_name\') to register a structure name. ' .
+                    'Registered document aliases: "%s"',
+                    $alias,
+                    $alias,
+                    implode('", "', array_keys($this->documentMetadata))
+                ));
+            }
+
+            if (!isset($this->documentMetadata[$alias])) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Unknown document alias "%s". Known document aliases "%s"',
+                    $alias,
+                    implode('", "', array_keys($this->documentMetadata))
+                ));
+            }
+            $metadata = $this->documentMetadata[$alias];
+
+            $structure = $this->structureMetaFactory->getStructureMetadata($metadata->getAlias(), $this->structureMap[$alias]);
+            $propertyMetadata = $structure->getProperty($propertyName);
+            $phpcrName = $this->encoder->fromProperty($propertyMetadata, $this->locale);
+
+            return array($alias, $phpcrName);
+        }
+
+        return parent::getPhpcrProperty($alias, $field);
+    }
+}

--- a/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
@@ -52,11 +52,6 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
      */
     private $documentRegistry;
 
-    /**
-     * @var string
-     */
-    private $defaultLocale;
-
     public function __construct(
         PropertyEncoder $encoder,
         WebspaceManagerInterface $webspaceManager,
@@ -102,6 +97,7 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
 
         $node = $event->getNode();
         $newLocale = $this->getAvailableLocalization($node, $document, $locale);
+
         $event->setLocale($newLocale);
 
         if ($newLocale === $locale) {

--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -20,6 +20,10 @@ use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 
+/**
+ * TODO: This could be made into a pure metadata subscriber if we make
+ *       the resource locator a system property.
+ */
 class ResourceSegmentSubscriber extends AbstractMappingSubscriber
 {
     private $inspector;

--- a/src/Sulu/Component/Content/Document/Subscriber/RouteSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RouteSubscriber.php
@@ -10,80 +10,38 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
-use Sulu\Component\DocumentManager\Event\HydrateEvent;
-use Symfony\Component\EventDispatcher\Event;
-use Sulu\Component\DocumentManager\Event\PersistEvent;
-use Sulu\Component\DocumentManager\PropertyEncoder;
-use Sulu\Component\DocumentManager\ProxyFactory;
-use Sulu\Component\DocumentManager\DocumentRegistry;
-use Sulu\Component\Content\Document\Behavior\RouteBehavior;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Event\MetadataLoadEvent;
+use Sulu\Component\Content\Document\Behavior\RouteBehavior;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class RouteSubscriber extends AbstractMappingSubscriber
+/**
+ * Behavior for route (sulu:path) documents
+ */
+class RouteSubscriber implements EventSubscriberInterface
 {
     const DOCUMENT_TARGET_FIELD = 'content';
 
-    private $proxyFactory;
-    private $documentRegistry;
-
-    /**
-     * @param PropertyEncoder  $encoder
-     * @param DocumentAccessor $accessor
-     * @param ProxyFactory     $proxyFactory
-     */
-    public function __construct(
-        PropertyEncoder $encoder,
-        ProxyFactory $proxyFactory,
-        DocumentRegistry $documentRegistry
-    ) {
-        parent::__construct($encoder);
-        $this->proxyFactory = $proxyFactory;
-        $this->documentRegistry = $documentRegistry;
-    }
-
-    public function supports($document)
+    public static function getSubscribedEvents()
     {
-        return $document instanceof RouteBehavior;
-    }
-
-    /**
-     * @param HydrateEvent $event
-     */
-    public function doHydrate(AbstractMappingEvent $event)
-    {
-        $node = $event->getNode();
-        $document = $event->getDocument();
-
-        $targetNode = $node->getPropertyValueWithDefault(
-            $this->encoder->systemName(self::DOCUMENT_TARGET_FIELD),
-            null
+        return array(
+            Events::METADATA_LOAD => 'handleMetadataLoad',
         );
+    }
 
-        $targetDocument = null;
-        if ($targetNode) {
-            $targetDocument = $this->proxyFactory->createProxyForNode($document, $targetNode);
+    public function handleMetadataLoad(MetadataLoadEvent $event)
+    {
+        $metadata = $event->getMetadata();
+
+        if (false === $metadata->getReflectionClass()->isSubclassOf(RouteBehavior::class)) {
+            return;
         }
 
-        $document->setTargetDocument($targetDocument);
-    }
-
-    /**
-     * @param PersistEvent $event
-     */
-    public function doPersist(PersistEvent $event)
-    {
-        $node = $event->getNode();
-        $document = $event->getDocument();
-        $targetDocument = $document->getTargetDocument();
-
-        $targetNode = null;
-        if ($targetDocument) {
-            $targetNode = $this->documentRegistry->getNodeForDocument($targetDocument);
-        }
-
-        $node->setProperty(
-            $this->encoder->systemName(self::DOCUMENT_TARGET_FIELD),
-            $targetNode
-        );
+        $metadata->addFieldMapping('targetDocument', array(
+            'encoding' => 'system',
+            'property' => self::DOCUMENT_TARGET_FIELD,
+            'type' => 'reference',
+        ));
     }
 }

--- a/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
@@ -39,7 +39,6 @@ class WebspaceSubscriber extends AbstractMappingSubscriber
         return array(
             // should happen after content is hydrated
             Events::HYDRATE => array('handleHydrate', -10),
-            Events::PERSIST => array('handlePersist', 10),
         );
     }
 
@@ -58,11 +57,7 @@ class WebspaceSubscriber extends AbstractMappingSubscriber
         $event->getAccessor()->set('webspaceName', $webspace);
     }
 
-    /**
-     * @param PersistEvent $event
-     */
     public function doPersist(PersistEvent $event)
     {
-        $this->doHydrate($event);
     }
 }

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -20,78 +20,82 @@ use PHPCR\NodeInterface;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Event\MetadataLoadEvent;
 
-class WorkflowStageSubscriber extends AbstractMappingSubscriber
+class WorkflowStageSubscriber implements EventSubscriberInterface
 {
     const WORKFLOW_STAGE_FIELD = 'state';
     const PUBLISHED_FIELD = 'published';
 
-    public function supports($document)
-    {
-        return $document instanceof WorkflowStageBehavior;
-    }
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
 
     /**
-     * @param HydrateEvent $event
+     * @param PropertyEncoder $encoder
      */
-    public function doHydrate(AbstractMappingEvent $event)
+    public function __construct(
+        PropertyEncoder $encoder
+    ) {
+        $this->encoder = $encoder;
+    }
+
+    public static function getSubscribedEvents()
     {
-        $locale = $event->getLocale();
-        $node = $event->getNode();
-        $document = $event->getDocument();
-
-        $workflowStage = $this->getWorkflowStage($node, $locale);
-        $document->setWorkflowStage($workflowStage);
-
-        $publishedDate = $event->getNode()->getPropertyValueWithDefault(
-            $this->encoder->localizedSystemName(self::PUBLISHED_FIELD, $event->getLocale()),
-            null
+        return array(
+            Events::METADATA_LOAD => 'handleMetadataLoad',
+            Events::PERSIST => 'handlePersist',
         );
-        $event->getAccessor()->set(
-            'published',
-            $publishedDate
-        );
+    }
+
+    public function handleMetadataLoad(MetadataLoadEvent $event)
+    {
+        $metadata = $event->getMetadata();
+
+        if (false === $metadata->getReflectionClass()->isSubclassOf(WorkflowStageBehavior::class)) {
+            return;
+        }
+
+        $metadata->addFieldMapping('workflowStage', array(
+            'encoding' => 'system_localized',
+            'property' => self::WORKFLOW_STAGE_FIELD,
+            'type' => 'long',
+        ));
+        $metadata->addFieldMapping('published', array(
+            'encoding' => 'system_localized',
+            'property' => self::PUBLISHED_FIELD,
+            'type' => 'date',
+        ));
     }
 
     /**
      * @param PersistEvent $event
      */
-    public function doPersist(PersistEvent $event)
+    public function handlePersist(PersistEvent $event)
     {
         $document = $event->getDocument();
+
+        if (!$document instanceof WorkflowStageBehavior) {
+            return;
+        }
+
         $stage = $document->getWorkflowStage();
         $node = $event->getNode();
         $locale = $event->getLocale();
         $persistedStage = $this->getWorkflowStage($node, $locale);
 
         if ($stage == WorkflowStage::PUBLISHED && $stage !== $persistedStage) {
-            $this->setPublishedDate($event->getAccessor(), $node, $locale, new \DateTime());
+            $event->getAccessor()->set(self::PUBLISHED_FIELD, new \DateTime());
         }
 
         if ($stage == WorkflowStage::TEST && $stage !== $persistedStage) {
-            $this->setPublishedDate($event->getAccessor(), $node, $locale, null);
+            $event->getAccessor()->set(self::PUBLISHED_FIELD, null);
         }
 
-        $this->setWorkflowStage($node, $stage, $locale);
-    }
-
-    private function setWorkflowStage(NodeInterface $node, $stage, $locale)
-    {
-        $node->setProperty(
-            $this->encoder->localizedSystemName(self::WORKFLOW_STAGE_FIELD, $locale),
-            (integer) $stage,
-            PropertyType::LONG
-        );
-    }
-
-    private function setPublishedDate(DocumentAccessor $accessor, NodeInterface $node, $locale, \DateTime $date = null)
-    {
-        $node->setProperty(
-            $this->encoder->localizedSystemName(self::PUBLISHED_FIELD, $locale),
-            $date,
-            PropertyType::DATE
-        );
-        $accessor->set('published', $date);
+        $document->setWorkflowStage($stage);
     }
 
     private function getWorkflowStage(NodeInterface $node, $locale)

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -453,7 +453,7 @@ class ContentMapper implements ContentMapperInterface
         $excludeGhost = true,
         $loadGhostContent = false
     ) {
-        $documents = $this->documentManager->createQuery($query, $locale, LegacyStructure::TYPE_PAGE)->execute();
+        $documents = $this->documentManager->createQuery($query, $locale)->execute();
 
         return $this->documentsToStructureCollection($documents, array(
             'exclude_ghost' => $excludeGhost,

--- a/tests/Sulu/Component/Content/Document/Query/QueryBuilderFunctionalTest.php
+++ b/tests/Sulu/Component/Content/Document/Query/QueryBuilderFunctionalTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Sulu\Component\Content\Document\Query;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Content\Document\WorkflowStage;
+
+class QueryBuilderFunctionalTest extends SuluTestCase
+{
+    public function setUp()
+    {
+        $this->manager = $this->getContainer()->get('sulu_document_manager.document_manager');
+    }
+
+    /**
+     * It should be able to use a structures fields as criteria.
+     */
+    public function testStructureFieldsCriteria()
+    {
+        $builder = $this->manager->createQueryBuilder();
+        $builder
+            ->setLocale('de')
+            ->useStructure('p', 'overview')
+            ->from()->document('page', 'p')->end()
+            ->where()->eq()->field('p.structure#article')->literal('hello');
+
+        $query = $builder->getQuery();
+        $this->assertEquals(
+            'SELECT * FROM [nt:unstructured] AS p WHERE (p.[i18n:de-article] = \'hello\' AND p.[jcr:mixinTypes] = \'sulu:page\')',
+            $query->getPhpcrQuery()->getStatement()
+        );
+    }
+
+    /**
+     * It should throw an exception if an unknown structure field is used.
+     *
+     * @expectedException InvalidArgumentException 
+     * @expectedExceptionMessage Unknown model property "foobar", in structure "overview". Known model properties: "title"
+     */
+    public function testUnknownStructureField()
+    {
+        $builder = $this->manager->createQueryBuilder();
+        $builder
+            ->setLocale('de')
+            ->useStructure('p', 'overview')
+            ->from()->document('page', 'p')->end()
+            ->where()->eq()->field('p.structure#foobar')->literal('hello');
+
+        $builder->getQuery();
+    }
+
+    /**
+     * The standard query builder should work as normal
+     */
+    public function testNormalQueryBuilder()
+    {
+        $builder = $this->manager->createQueryBuilder();
+        $builder
+            ->setLocale('de')
+            ->useStructure('p', 'overview')
+            ->from()->document('page', 'p')->end()
+            ->where()->eq()->field('p.workflowStage')->literal(WorkflowStage::PUBLISHED);
+
+        $query = $builder->getQuery();
+        $this->assertEquals(
+            'SELECT * FROM [nt:unstructured] AS p WHERE (p.[i18n:de-state] = CAST(\'2\' AS LONG) AND p.[jcr:mixinTypes] = \'sulu:page\')',
+            $query->getPhpcrQuery()->getStatement()
+        );
+    }
+}

--- a/tests/Sulu/Component/Content/Document/Query/QueryBuilderTest.php
+++ b/tests/Sulu/Component/Content/Document/Query/QueryBuilderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sulu\Component\Content\Document\Query;
+
+class QueryBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    private $queryBuilder;
+
+    public function setUp()
+    {
+        $this->queryBuilder = new QueryBuilder();
+    }
+
+    /**
+     * Is should assign a structure name to a document alias
+     * It should get the document alias to structure name map
+     */
+    public function testStructure()
+    {
+        $this->queryBuilder->useStructure('p', 'overview');
+        $this->assertEquals(array(
+            'p' => 'overview',
+        ), $this->queryBuilder->getStructureMap());
+    }
+}

--- a/tests/Sulu/Component/Content/Document/Query/StructureQueryBuilderConverterTest.php
+++ b/tests/Sulu/Component/Content/Document/Query/StructureQueryBuilderConverterTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Sulu\Component\Content\Document\Query;
+
+class StructureQueryBuilderConverterTest extends SuluTestCase
+{
+
+    public function setUp()
+    {
+        $this->converter = 
+    }
+}

--- a/tests/Sulu/Component/Content/Document/Subscriber/OrderSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/OrderSubscriberTest.php
@@ -20,19 +20,22 @@ class OrderSubscriberTest extends SubscriberTestCase
         parent::setUp();
 
         $this->subscriber = new OrderSubscriber($this->encoder->reveal());
-        $this->hydrateEvent->getDocument()->willReturn(new TestOrderDocument(10));
-        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->persistEvent->getDocument()->willReturn(new TestOrderDocument(null));
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
     }
 
     /**
      * It should set the order on the document.
      */
-    public function testHydrateOrder()
+    public function testPersistOrder()
     {
-        $this->encoder->systemName('order')->willReturn('sys:order');
-        $this->node->getPropertyValueWithDefault('sys:order', null)->willReturn(50);
-        $this->accessor->set('suluOrder', 50)->shouldBeCalled();
-        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+        $this->parentNode->getNodes()->willReturn(array(
+            $this->node->reveal()
+        ));
+        $this->persistEvent->getAccessor()->willReturn($this->accessor->reveal());
+        $this->accessor->set('suluOrder', 20)->shouldBeCalled();
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 }
 

--- a/tests/Sulu/Component/Content/Document/Subscriber/SubscriberTestCase.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/SubscriberTestCase.php
@@ -25,6 +25,7 @@ class SubscriberTestCase extends \PHPUnit_Framework_TestCase
         $this->notImplementing = new \stdClass;
         $this->encoder = $this->prophesize(PropertyEncoder::class);
         $this->node = $this->prophesize(NodeInterface::class);
+        $this->parentNode = $this->prophesize(NodeInterface::class);
         $this->accessor = $this->prophesize(DocumentAccessor::class);
         $this->persistEvent->getNode()->willReturn($this->node);
         $this->hydrateEvent->getAccessor()->willReturn($this->accessor);

--- a/tests/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriberTest.php
@@ -32,6 +32,7 @@ class WorkflowStageSubscriberTest extends SubscriberTestCase
         $this->subscriber = new WorkflowStageSubscriber($this->encoder->reveal());
 
         $this->persistEvent->getNode()->willReturn($this->node);
+        $this->persistEvent->getAccessor()->willReturn($this->accessor->reveal());
     }
 
     /**
@@ -45,13 +46,11 @@ class WorkflowStageSubscriberTest extends SubscriberTestCase
         $this->persistEvent->getDocument()->willReturn($document);
         $this->persistEvent->getLocale()->willReturn('fr');
 
-        $this->encoder->localizedSystemName(WorkflowStageSubscriber::PUBLISHED_FIELD, 'fr')->willReturn('published');
         $this->encoder->localizedSystemName(WorkflowStageSubscriber::WORKFLOW_STAGE_FIELD, 'fr')->willReturn('stage');
-        $this->node->setProperty('published', Argument::type('DateTime'), PropertyType::DATE)->shouldBeCalled();
-        $this->node->setProperty('stage', WorkflowStage::PUBLISHED, PropertyType::LONG)->shouldBeCalled();
-        $this->persistEvent->getAccessor()->willReturn($this->accessor->reveal());
 
-        $this->subscriber->doPersist(
+        $this->assertEquals(WorkflowStage::PUBLISHED, $document->getWorkflowStage());
+        $this->accessor->set('published', Argument::type('DateTime'))->shouldBeCalled();
+        $this->subscriber->handlePersist(
             $this->persistEvent->reveal()
         );
     }
@@ -66,13 +65,11 @@ class WorkflowStageSubscriberTest extends SubscriberTestCase
 
         $this->persistEvent->getDocument()->willReturn($document);
         $this->persistEvent->getLocale()->willReturn('fr');
-        $this->encoder->localizedSystemName(WorkflowStageSubscriber::PUBLISHED_FIELD, 'fr')->willReturn('published');
         $this->encoder->localizedSystemName(WorkflowStageSubscriber::WORKFLOW_STAGE_FIELD, 'fr')->willReturn('stage');
-        $this->node->setProperty('stage', WorkflowStage::PUBLISHED, PropertyType::LONG)->shouldBeCalled();
 
-        $this->node->setProperty('published', Argument::type('DateTime'), PropertyType::DATE)->shouldNotBeCalled();
-
-        $this->subscriber->doPersist(
+        $this->accessor->set('published', Argument::type('DateTime'))->shouldNotBeCalled();
+        $this->assertEquals(WorkflowStage::PUBLISHED, $document->getWorkflowStage());
+        $this->subscriber->handlePersist(
             $this->persistEvent->reveal()
         );
     }

--- a/tests/Sulu/Component/Content/Mapper/ContentMapperTest.php
+++ b/tests/Sulu/Component/Content/Mapper/ContentMapperTest.php
@@ -100,11 +100,10 @@ class ContentMapperTest extends SuluTestCase
         $this->assertEquals('sulu_io', $result->getPropertyValue('article'));
         $this->assertEmpty($result->getNavContexts());
 
-        $root = $this->session->getRootNode();
         $route = $this->documentManager->find('/cmf/sulu_io/routes/de/news/test', 'de');
-
         $page = $route->getTargetDocument();
 
+        $this->assertNotNull($page);
         $this->assertEquals('Testname', $page->getTitle());
         $this->assertEquals('sulu_io', $page->getStructure()->getProperty('article')->getValue());
         $this->assertEquals(array('tag1', 'tag2'), $page->getStructure()->getProperty('tags')->getValue());
@@ -2487,7 +2486,7 @@ class ContentMapperTest extends SuluTestCase
         $structure1 = $this->mapper->save($data1, 'default', 'sulu_io', 'en', 1);
 
         $data2 = array(
-            'title' => 'Test',
+            'title' => 'Test 1',
             'nodeType' => Structure::NODE_TYPE_INTERNAL_LINK,
             'internal_link' => $structure1->getUuid(),
         );


### PR DESCRIPTION
This PR applies the Metadata Mapping feature which is being introduced in the Doucment Manager.

Each subscriber can register mapping with the Metadata object. A single subscriber (in the Document Manager) can then take care of the details of reading and writing to the PHPCR node.

In addition, having the field information in the Metadata exposes which fields can be queried on in a query builder or domain specific query language.

This PR also includes the QueryBuilder.