### PR TITLE
Do not index non tagged block fields

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Behat/BaseStructureContext.php
+++ b/src/Sulu/Bundle/ContentBundle/Behat/BaseStructureContext.php
@@ -16,6 +16,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Mapper\ContentMapperRequest;
+use Sulu\Bundle\TestBundle\Behat\BaseContext;
 
 /**
  * Base context class for Structure based feature contexts.
@@ -143,6 +144,7 @@ class BaseStructureContext extends BaseContext implements SnippetAcceptingContex
     protected function createStructureTemplate($type, $name, $template)
     {
         $paths = $this->getContainer()->getParameter('sulu.content.structure.paths');
+        // FIX THIS
         $paths = array_filter($paths, function ($value) use ($type) {
             if ($value['type'] == $type) {
                 return true;

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.BasePageDocument.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.BasePageDocument.xml
@@ -20,6 +20,7 @@
         <property name="structureType" type="string" />
         <property name="locale" type="string" />
         <property name="path" type="string" />
+        <property name="webspaceName" type="string" />
         <property name="extensions" type="Sulu\Component\Content\Document\Extension\ExtensionContainer" />
 
         <property name="structure" type="Sulu\Component\Content\Document\Structure\Structure" />

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -134,6 +134,10 @@ class StructureProvider implements ProviderInterface
                 $propertyMapping = new ComplexMetadata();
                 foreach ($property->getComponents() as $component) {
                     foreach ($component->getChildren() as $componentProperty) {
+                        if (false === $componentProperty->hasTag('sulu.search.field')) {
+                            continue;
+                        }
+
                         $propertyMapping->addFieldMapping(
                             'title',
                             array(

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeResourcelocatorControllerTest.php
@@ -19,7 +19,7 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
     /**
      * @var Client
      */
-    private $client;
+    protected $client;
 
     /**
      * @var array

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/BaseTestCase.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/BaseTestCase.php
@@ -11,10 +11,10 @@
 namespace Sulu\Bundle\ContentBundle\Tests\Functional\Search;
 
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
-use Sulu\Bundle\SearchBundle\Tests\Fixtures\DefaultStructureCache;
+use Sulu\Bundle\SearchBundle\Tests\Fixtures\DefaultDocumentCache;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Sulu\Component\Content\Compat\Structure;
-use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Content\Compat\Document;
+use Sulu\Component\Content\Compat\DocumentInterface;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -27,11 +27,10 @@ class BaseTestCase extends SuluTestCase
     public function setUp()
     {
         $this->initPhpcr();
-        $fs = new Filesystem();
-        $fs->remove(__DIR__ . '/../app/data');
 
         $this->session = $this->getContainer()->get('doctrine_phpcr')->getConnection();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+        $this->getSearchManager()->purge('page');
         $this->webspaceDocument = $this->documentManager->find('/cmf/sulu_io/contents');
     }
 
@@ -42,13 +41,13 @@ class BaseTestCase extends SuluTestCase
         return $searchManager;
     }
 
-    public function generateStructureIndex($count)
+    public function generateDocumentIndex($count)
     {
         $documents = array();
         for ($i = 1; $i <= $count; $i++) {
             $pageDocument = new PageDocument();
             $pageDocument->setParent($this->webspaceDocument);
-            $pageDocument->setTitle('Structure Title ' . $i);
+            $pageDocument->setTitle('Document Title ' . $i);
             $pageDocument->setWorkflowStage(WorkflowStage::PUBLISHED);
 
             $this->documentManager->persist($pageDocument, 'de');
@@ -60,7 +59,7 @@ class BaseTestCase extends SuluTestCase
         return $documents;
     }
 
-    public function indexStructure($title, $url)
+    public function indexDocument($title, $url)
     {
         /** @var ContentMapperInterface $mapper */
         $document = $this->documentManager->create('page');

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/DeleteDocumentTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/DeleteDocumentTest.php
@@ -10,20 +10,20 @@
 
 namespace Sulu\Bundle\ContentBundle\Tests\Functional\Search;
 
-use Sulu\Bundle\SearchBundle\Tests\Fixtures\SecondStructureCache;
-use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Bundle\SearchBundle\Tests\Fixtures\SecondDocumentCache;
+use Sulu\Component\Content\Compat\DocumentInterface;
 use Sulu\Component\Content\Compat\PropertyTag;
-use Sulu\Component\Content\Compat\Structure;
+use Sulu\Component\Content\Compat\Document;
 use Sulu\Component\Content\Mapper\ContentMapperRequest;
 
-class DeleteStructureTest extends BaseTestCase
+class DeleteDocumentTest extends BaseTestCase
 {
-    public function testDeleteStructure()
+    public function testDeleteDocument()
     {
         $searchManager = $this->getSearchManager();
         $mapper = $this->getContainer()->get('sulu.content.mapper');
 
-        $structure = $this->indexStructure('About Us', '/about-us');
+        $structure = $this->indexDocument('About Us', '/about-us');
         $this->documentManager->flush();
 
         $res = $searchManager->createSearch('About')->locale('de')->index('page')->execute();

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/SaveDocumentTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/SaveDocumentTest.php
@@ -11,21 +11,21 @@
 namespace Sulu\Bundle\ContentBundle\Tests\Functional\Search;
 
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
-use Sulu\Bundle\SearchBundle\Tests\Fixtures\SecondStructureCache;
+use Sulu\Bundle\SearchBundle\Tests\Fixtures\SecondDocumentCache;
 use Sulu\Component\Content\Compat\PropertyTag;
-use Sulu\Component\Content\Compat\Structure;
-use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Content\Compat\Document;
+use Sulu\Component\Content\Compat\DocumentInterface;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Mapper\ContentMapperRequest;
 
-class SaveStructureTest extends BaseTestCase
+class SaveDocumentTest extends BaseTestCase
 {
     /**
      * Check that the automatic indexing works.
      */
-    public function testSaveStructure()
+    public function testSaveDocument()
     {
-        $this->indexStructure('About Us', '/about-us');
+        $this->indexDocument('About Us', '/about-us');
 
         $searchManager = $this->getSearchManager();
         $res = $searchManager->createSearch('About')->locale('de')->index('page')->execute();
@@ -38,7 +38,7 @@ class SaveStructureTest extends BaseTestCase
         $this->assertEquals(null, $document->getDescription());
     }
 
-    public function testSaveStructureWithBlocks()
+    public function testSaveDocumentWithBlocks()
     {
         $document = new PageDocument();
         $document->setTitle('Places');
@@ -56,6 +56,7 @@ class SaveStructureTest extends BaseTestCase
                     'type' => 'article',
                     'title' => 'Basel',
                     'article' => 'Basel Switzerland',
+                    'lines' => array('line1', 'line2'),
                 ),
             )), false);
         $document->setParent($this->webspaceDocument);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/SearchManagerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/SearchManagerTest.php
@@ -21,14 +21,14 @@ class SearchManagerTest extends BaseTestCase
     public function testSearchManager()
     {
         $nbResults = 10;
-        $documents = $this->generateStructureIndex($nbResults);
+        $documents = $this->generateDocumentIndex($nbResults);
 
         for ($i = 1; $i <= 2; $i++) {
             foreach ($documents as $document) {
                 $this->documentManager->persist($document, 'de');
             }
 
-            $res = $this->getSearchManager()->createSearch('Structure')->locale('de')->index('page')->execute();
+            $res = $this->getSearchManager()->createSearch('Document')->locale('de')->index('page')->execute();
 
             $this->assertCount($nbResults, $res);
         }
@@ -36,9 +36,9 @@ class SearchManagerTest extends BaseTestCase
 
     public function testSearchByWebspace()
     {
-        $this->generateStructureIndex(4, 'webspace_four');
-        $this->generateStructureIndex(2, 'webspace_two');
-        $result = $this->getSearchManager()->createSearch('Structure')->locale('de')->index('page')->execute();
+        $this->generateDocumentIndex(4);
+        $this->generateDocumentIndex(2);
+        $result = $this->getSearchManager()->createSearch('Document')->locale('de')->index('page')->execute();
         $this->assertCount(6, $result);
 
         $firstHit = reset($result);
@@ -52,7 +52,7 @@ class SearchManagerTest extends BaseTestCase
         }
 
         // TODO: This should should not be here
-        $res = $this->getSearchManager()->createSearch('+webspaceKey:webspace_four Structure*')->locale('de')->index('page')->execute();
-        $this->assertCount(4, $res);
+        $res = $this->getSearchManager()->createSearch('+webspace_key:sulu_io')->locale('de')->index('page')->execute();
+        $this->assertCount(6, $res);
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/blocks.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/blocks.xml
@@ -75,6 +75,13 @@
                             <tag name="sulu.search.field" type="string" />
                         </property>
 
+                        <property name="lines" type="text_line" minOccurs="2" maxOccurs="2" mandatory="false">
+                            <meta>
+                                <title lang="de">Lines</title>
+                                <title lang="en">Lines</title>
+                            </meta>
+                        </property>
+
                     </properties>
                 </type>
             </types>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/config/search.yml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/config/search.yml
@@ -1,5 +1,8 @@
 massive_search:
-    adapter: test
+    adapter: zend_lucene
+    adapters:
+        zend_lucene:
+            hide_index_exception: true
 
 sulu_content:
     search:

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
@@ -27,7 +27,7 @@ class SearchControllerTest extends SuluTestCase
     /**
      * @var Client
      */
-    private $client;
+    protected $client;
 
     /**
      * @var EntityManager

--- a/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/CodeControllerTest.php
+++ b/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/CodeControllerTest.php
@@ -98,7 +98,7 @@ class CodeControllerTest extends SuluTestCase
     /**
      * @var Client
      */
-    private $client;
+    protected $client;
 
     /**
      * @var int

--- a/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
@@ -16,7 +16,7 @@ use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\DocumentManager\Events;
-use Sulu\Component\Document\Behavior\WebspaceBehavior;
+use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 
 class WebspaceSubscriber extends AbstractMappingSubscriber


### PR DESCRIPTION
This PR prevents all block properties from being indexed by default.

In addition it fixes the webspace indexing, changes the search tests to use the `zend_lucene` implementation (instead of the `test` adapter) and fixes a behat issue.