### PR TITLE
reenabled csrf protection and disabled it only for the content mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1316 [ContentBundle]  Reenabled csrf protection and disabled it only for the content mapper
     * FEATURE     #1314 [AdminBundle]    Added search component to the sulu dashboard
     * FEATURE     #1273 [SnippetBundle]  Removed snippet state from ui and set default published
     * BUGFIX      #1308 [ContactBundle]  Fixed adding a new contact-account relation in contacts tab of account

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -4,6 +4,7 @@ framework:
     templating: { engines: ['twig'] }
     form:
         enabled: true
+    csrf_protection: ~
     test: ~
     session:
         storage_id: session.storage.mock_file

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -233,6 +233,9 @@ class ContentMapper implements ContentMapperInterface
             $options['webspace_key'] = $webspaceKey;
         }
 
+        // disable csrf protection, since we can't produce a token, because the form is cached on the client
+        $options['csrf_protection'] = false;
+
         $form = $this->formFactory->create($documentAlias, $document, $options);
 
         $clearMissing = false;


### PR DESCRIPTION
Also reintroduces the possibility to use csrf protection on the website.
Should be merged together with https://github.com/sulu-io/sulu-standard/pull/471, since this PR is enabling the csrf_protection again.

__tasks:__

- [ ] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none