### PR TITLE
fixed database builder for instantiating not exsting database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #1366 [CoreBundle]     Fixed build command for not existing database
+
 * 1.0.1 (2015-07-06)
     * HOTFIX      #1338 [Content]        Fixed wrong check for block type meta title
 

--- a/src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
@@ -10,6 +10,8 @@
 
 namespace Sulu\Bundle\CoreBundle\Build;
 
+use Doctrine\DBAL\Exception\ConnectionException;
+
 /**
  * Builder for initializing the (relational) database.
  */
@@ -38,12 +40,12 @@ class DatabaseBuilder extends SuluBuilder
     {
         $doctrine = $this->container->get('doctrine');
         $connection = $databaseExists = $doctrine->getConnection();
-        $schemaManager = $connection->getSchemaManager();
 
         try {
+            $schemaManager = $connection->getSchemaManager();
             $databaseExists = true;
             $schemaManager->listDatabases();
-        } catch (\Exception $e) {
+        } catch (ConnectionException $e) {
             $databaseExists = false;
         }
 


### PR DESCRIPTION
There was an error if the database has not been created yet in the `app/console sulu:build` command.
The "test" is in https://github.com/sulu-io/sulu-standard/pull/479

__tasks:__

- [x] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none