### PR TITLE
Fixed sorting of pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG for Sulu
     * HOTFIX      #1395 [ContentBundle]  Fixed cache-lifetime is required bug for lifetime "0"
     * HOTFIX      #1386 [ContentBundle]  Fixed hard-coded values in search metadata
     * HOTFIX      #1400 [SnippetBundle]  Fixed block sorting in snippet form
+    * HOTFIX      #1378 [ContentBundle]   Fixed sorting of pages
 
 * 1.0.2 (2015-07-13)
     * HOTFIX      #1355 [CoreBundle]     Fixed creator id for website document

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -47,7 +47,7 @@ class StructureProvider implements ProviderInterface
     private $mapping;
 
     /**
-     * @var StructureFactory
+     * @var StructureMetadataFactory
      */
     private $structureFactory;
 

--- a/src/Sulu/Component/Content/Document/Subscriber/AbstractMappingSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/AbstractMappingSubscriber.php
@@ -24,7 +24,6 @@ abstract class AbstractMappingSubscriber implements EventSubscriberInterface
 
     /**
      * @param PropertyEncoder  $encoder
-     * @param DocumentAccessor $accessor
      */
     public function __construct(PropertyEncoder $encoder)
     {
@@ -43,7 +42,7 @@ abstract class AbstractMappingSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param HydrateEvent $event
+     * @param AbstractMappingEvent $event
      */
     public function handleHydrate(AbstractMappingEvent $event)
     {
@@ -76,7 +75,7 @@ abstract class AbstractMappingSubscriber implements EventSubscriberInterface
     abstract protected function doPersist(PersistEvent $event);
 
     /**
-     * @param DocumentInterface $document
+     * @param object $document
      */
     abstract protected function supports($document);
 

--- a/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
@@ -39,9 +39,10 @@ class OrderSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Checks if the given document is supported by this subscriber
+     * Checks if the given document is supported by this subscriber.
      *
      * @param $document
+     *
      * @return bool
      */
     public function supports($document)
@@ -62,7 +63,7 @@ class OrderSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Adjusts the order of the document and its siblings
+     * Adjusts the order of the document and its siblings.
      *
      * @param PersistEvent $event
      */
@@ -90,7 +91,7 @@ class OrderSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Adjusts the order of the document and its siblings
+     * Adjusts the order of the document and its siblings.
      *
      * @param ReorderEvent $event
      */
@@ -116,7 +117,7 @@ class OrderSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Adds the order to the document
+     * Adds the order to the document.
      *
      * @param AbstractMappingEvent $event
      */

--- a/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
@@ -12,8 +12,9 @@
 namespace Sulu\Component\Content\Document\Subscriber;
 
 use PHPCR\PropertyType;
-use Sulu\Component\Content\Document\Behavior\OrderBehavior;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\Content\Document\Behavior\OrderBehavior;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\PropertyEncoder;
@@ -27,6 +28,9 @@ class OrderSubscriber implements EventSubscriberInterface
 {
     const FIELD = 'order';
 
+    /**
+     * @var PropertyEncoder
+     */
     private $encoder;
 
     public function __construct(PropertyEncoder $encoder)
@@ -34,6 +38,11 @@ class OrderSubscriber implements EventSubscriberInterface
         $this->encoder = $encoder;
     }
 
+    /**
+     * Checks if the given document is supported by this subscriber
+     * @param $document
+     * @return bool
+     */
     public function supports($document)
     {
         return $document instanceof OrderBehavior;
@@ -51,6 +60,7 @@ class OrderSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * Adjusts the order of the document and its siblings
      * @param PersistEvent $event
      */
     public function handlePersist(PersistEvent $event)
@@ -64,19 +74,18 @@ class OrderSubscriber implements EventSubscriberInterface
 
         $propertyName = $this->encoder->systemName(self::FIELD);
 
-        if ($node->hasProperty($propertyName)) {
-            return;
+        $parent = $node->getParent();
+        $count = 0;
+        foreach ($parent->getNodes() as $childNode) {
+            $childNode->setProperty($propertyName, ($count + 1) * 10, PropertyType::LONG);
+            ++$count;
         }
 
-        $parent = $node->getParent();
-        $nodeCount = count($parent->getNodes());
-        $order = ($nodeCount + 1) * 10;
-
-        $node->setProperty($propertyName, $order, PropertyType::LONG);
         $this->handleHydrate($event);
     }
 
     /**
+     * Adds the order to the document
      * @param HydrateEvent $event
      */
     public function handleHydrate(AbstractMappingEvent $event)

--- a/tests/Sulu/Component/Content/Document/Subscriber/OrderSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/OrderSubscriberTest.php
@@ -11,11 +11,18 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
+use Prophecy\Argument;
 use Sulu\Component\Content\Document\Behavior\OrderBehavior;
-use Sulu\Component\DocumentManager\Event\HydrateEvent;
 
 class OrderSubscriberTest extends SubscriberTestCase
 {
+    /**
+     * @var OrderSubscriber
+     */
+    private $subscriber;
+
     public function setUp()
     {
         parent::setUp();
@@ -23,6 +30,50 @@ class OrderSubscriberTest extends SubscriberTestCase
         $this->subscriber = new OrderSubscriber($this->encoder->reveal());
         $this->hydrateEvent->getDocument()->willReturn(new TestOrderDocument(10));
         $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+    }
+
+    public function testPersistNewNode()
+    {
+        $document = $this->prophesize(OrderBehavior::class);
+        $this->persistEvent->getDocument()->willReturn($document);
+        $this->encoder->systemName('order')->willReturn('sys:order');
+
+        $node1 = $this->prophesize(NodeInterface::class);
+        $node2 = $this->prophesize(NodeInterface::class);
+        $node3 = $this->prophesize(NodeInterface::class);
+
+        $parentNode = $this->prophesize(NodeInterface::class);
+        $parentNode->getNodes()->willReturn(array($node1, $node2, $node3, $this->node));
+        $this->node->getParent()->willReturn($parentNode);
+        $node1->setProperty('sys:order', 10, PropertyType::LONG)->shouldBeCalled();
+        $node2->setProperty('sys:order', 20, PropertyType::LONG)->shouldBeCalled();
+        $node3->setProperty('sys:order', 30, PropertyType::LONG)->shouldBeCalled();
+        $this->node->setProperty('sys:order', 40, PropertyType::LONG)->shouldBeCalled();
+        $this->node->getPropertyValueWithDefault('sys:order', null)->willReturn(40);
+        $this->accessor->set('suluOrder', 40)->shouldBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    public function testPersistExistingNode()
+    {
+        $document = $this->prophesize(OrderBehavior::class);
+        $this->persistEvent->getDocument()->willReturn($document);
+        $this->encoder->systemName('order')->willReturn('sys:order');
+
+        $node2 = $this->prophesize(NodeInterface::class);
+        $node3 = $this->prophesize(NodeInterface::class);
+
+        $parentNode = $this->prophesize(NodeInterface::class);
+        $parentNode->getNodes()->willReturn(array($this->node, $node2, $node3));
+        $this->node->getParent()->willReturn($parentNode);
+        $this->node->setProperty('sys:order', 10, PropertyType::LONG)->shouldBeCalled();
+        $node2->setProperty('sys:order', 20, PropertyType::LONG)->shouldBeCalled();
+        $node3->setProperty('sys:order', 30, PropertyType::LONG)->shouldBeCalled();
+        $this->node->getPropertyValueWithDefault('sys:order', null)->willReturn(40);
+        $this->accessor->set('suluOrder', 40)->shouldBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 
     /**

--- a/tests/Sulu/Component/Content/Document/Subscriber/OrderSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/OrderSubscriberTest.php
@@ -13,9 +13,7 @@ namespace Sulu\Component\Content\Document\Subscriber;
 
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
-use Prophecy\Argument;
 use Sulu\Component\Content\Document\Behavior\OrderBehavior;
-use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Event\ReorderEvent;
 
 class OrderSubscriberTest extends SubscriberTestCase
@@ -45,7 +43,7 @@ class OrderSubscriberTest extends SubscriberTestCase
         $node3 = $this->prophesize(NodeInterface::class);
 
         $parentNode = $this->prophesize(NodeInterface::class);
-        $parentNode->getNodes()->willReturn(array($node1, $node2, $node3));
+        $parentNode->getNodes()->willReturn([$node1, $node2, $node3]);
         $this->node->hasProperty('sys:order')->willReturn(false);
         $this->node->getParent()->willReturn($parentNode);
         $this->node->setProperty('sys:order', 40, PropertyType::LONG)->shouldBeCalled();
@@ -68,7 +66,7 @@ class OrderSubscriberTest extends SubscriberTestCase
         $node3 = $this->prophesize(NodeInterface::class);
 
         $parentNode = $this->prophesize(NodeInterface::class);
-        $parentNode->getNodes()->willReturn(array($this->node, $node2, $node3));
+        $parentNode->getNodes()->willReturn([$this->node, $node2, $node3]);
         $this->node->getParent()->willReturn($parentNode);
         $this->node->setProperty('sys:order', 10, PropertyType::LONG)->shouldBeCalled();
         $node2->setProperty('sys:order', 20, PropertyType::LONG)->shouldBeCalled();

--- a/tests/Sulu/Component/Content/Document/Subscriber/SubscriberTestCase.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/SubscriberTestCase.php
@@ -58,6 +58,7 @@ class SubscriberTestCase extends \PHPUnit_Framework_TestCase
         $this->node = $this->prophesize(NodeInterface::class);
         $this->accessor = $this->prophesize(DocumentAccessor::class);
         $this->persistEvent->getNode()->willReturn($this->node);
+        $this->persistEvent->getAccessor()->willReturn($this->accessor);
         $this->hydrateEvent->getAccessor()->willReturn($this->accessor);
     }
 }


### PR DESCRIPTION
The `sulu:order` property have not been properly updated for existing pages, this worked only for new ones. This PR fixes that.

Should be also merged to master, and probably be released as a hotfix.

__tasks:__

- [x] test coverage
- [x] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | fixes #1377 
| BC breaks        | none
| Documentation PR | none