### PR TITLE
set published to date instead boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG for Sulu
     * HOTFIX      #1395 [ContentBundle]  Fixed cache-lifetime is required bug for lifetime "0"
     * HOTFIX      #1386 [ContentBundle]  Fixed hard-coded values in search metadata
     * HOTFIX      #1400 [SnippetBundle]  Fixed block sorting in snippet form
+    * HOTFIX      #1414 [ContentBundle]  Set published property in resolved smart content to date instead boolean
 
 * 1.0.2 (2015-07-13)
     * HOTFIX      #1355 [CoreBundle]     Fixed creator id for website document

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -974,7 +974,7 @@ class ContentMapper implements ContentMapperInterface
             'changed' => $document->getChanged(),
             'changer' => $document->getChanger(),
             'created' => $document->getCreated(),
-            'published' => $document->getWorkflowStage() === WorkflowStage::PUBLISHED,
+            'published' => $document->getPublished(),
             'creator' => $document->getCreator(),
             'title' => $originalDocument->getTitle(),
             'url' => $url,

--- a/tests/app/Resources/pages/overview_smart_content.xml
+++ b/tests/app/Resources/pages/overview_smart_content.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>overview</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <tag name="sulu.rlp.part" />
+        </property>
+        <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp" />
+        </property>
+        <property name="article" type="text_area" mandatory="false"/>
+        <property name="blog" type="text_area" mandatory="false"/>
+        <property name="external" type="url" mandatory="false"/>
+        <property name="smartcontent" type="smart_content"/>
+    </properties>
+</template>
+


### PR DESCRIPTION
The `published` value in the resolved smart content was a boolean again, instead of a `DateTime` object.

__tasks:__

- [x] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | fixes #648 (again)
| BC breaks        | `published` is a `DateTime` object instead of a boolean
| Documentation PR | none