### PR TITLE
Cast DoctrineListBuilder::count return value to an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1462 [Rest]            Fixed type of returned value for the Doctrine list builder count method
     * BUGFIX      #1437 [SnippetBundle]   Fixed copy-locale overlay bug
     * FEATURE     #1424 [All]             Implemented and integrated expressions for the listbuilder
     * FEATURE     #1429 [ResourceBundle]  Updated husky and added preselect for filter dropdown

--- a/src/Sulu/Component/Localization/Provider/LocalizationProvider.php
+++ b/src/Sulu/Component/Localization/Provider/LocalizationProvider.php
@@ -53,7 +53,7 @@ class LocalizationProvider implements LocalizationProviderInterface
 
         $localization = new Localization();
         $localization->setLanguage($parts[0]);
-        if (sizeof($parts) > 1) {
+        if (count($parts) > 1) {
             $localization->setCountry($parts[1]);
         }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -101,7 +101,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         } elseif ($numResults == 1) {
             $result = array_values($result[0]);
 
-            return $result[0];
+            return (int) $result[0];
         }
 
         return 0;


### PR DESCRIPTION
When the value is provided by a Doctrine query result, it was returned as a string.

__Information__

| Q                | A
| ---------------- | ---
| Fixed tickets    | N/A
| BC breaks        | None
| Documentation PR | N/A