### PR TITLE
fixed displayOptions in media selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #1469 [ContentBundle]  fixed displayOptions in media selection
     * HOTFIX      #1468 [SnippetBundle]  Fixed default language for snippets in administration
 
 * 1.0.6 (2015-08-05)

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
@@ -16,6 +16,7 @@ use Sulu\Component\Content\Metadata\Loader\Exception\InvalidXmlException;
 use Sulu\Component\Content\Metadata\Loader\Exception\RequiredPropertyNameNotFoundException;
 use Sulu\Component\Content\Metadata\Loader\Exception\RequiredTagNotFoundException;
 use Sulu\Component\Content\Metadata\Loader\Exception\ReservedPropertyNameException;
+use Sulu\Exception\FeatureNotImplementedException;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\Config\Util\XmlUtils;
@@ -213,8 +214,8 @@ class XmlLegacyLoader implements LoaderInterface
             throw new ReservedPropertyNameException($templateKey, $result['name']);
         }
 
-        $result['mandatory'] = $this->getBooleanValueFromXPath('@mandatory', $xpath, $node, false);
-        $result['multilingual'] = $this->getBooleanValueFromXPath('@multilingual', $xpath, $node, true);
+        $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
+        $result['multilingual'] = $this->getValueFromXPath('@multilingual', $xpath, $node, true);
         $result['tags'] = $this->loadTags('x:tag', $tags, $xpath, $node);
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
         $result['meta'] = $this->loadMeta('x:meta/x:*', $xpath, $node);
@@ -233,7 +234,7 @@ class XmlLegacyLoader implements LoaderInterface
             ['name', 'default-type', 'minOccurs', 'maxOccurs', 'colspan', 'cssClass']
         );
 
-        $result['mandatory'] = $this->getBooleanValueFromXPath('@mandatory', $xpath, $node, false);
+        $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
         $result['type'] = 'block';
         $result['tags'] = $this->loadTags('x:tag', $tags, $xpath, $node);
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
@@ -456,18 +457,6 @@ class XmlLegacyLoader implements LoaderInterface
     }
 
     /**
-     * returns boolean value of path.
-     */
-    private function getBooleanValueFromXPath($path, \DOMXPath $xpath, \DomNode $context = null, $default = null)
-    {
-        if (($value = $this->getValueFromXPath($path, $xpath, $context)) != null) {
-            return $value === 'true' ? true : false;
-        } else {
-            return $default;
-        }
-    }
-
-    /**
      * returns value of path.
      */
     private function getValueFromXPath($path, \DOMXPath $xpath, \DomNode $context = null, $default = null)
@@ -481,6 +470,14 @@ class XmlLegacyLoader implements LoaderInterface
             $item = $result->item(0);
             if ($item === null) {
                 return $default;
+            }
+
+            if ('true' === $item->nodeValue) {
+                return true;
+            }
+
+            if ('false' === $item->nodeValue) {
+                return false;
             }
 
             return $item->nodeValue;

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
@@ -21,8 +21,6 @@ use Symfony\Component\Config\Loader\LoaderResolverInterface;
 
 /**
  * Load structure structure from an XML file.
- *
- * @author Daniel Leech <daniel@dantleech.com>
  */
 class XmlLoader extends XmlLegacyLoader
 {

--- a/tests/Resources/DataFixtures/Page/template.xml
+++ b/tests/Resources/DataFixtures/Page/template.xml
@@ -55,6 +55,17 @@
             <params>
                 <param name="minLinks" value="1"/>
                 <param name="maxLinks" value="10"/>
+                <param name="displayOptions" type="collection">
+                    <param name="leftTop" value="true"/>
+                    <param name="top" value="false"/>
+                    <param name="rightTop" value="true"/>
+                    <param name="left" value="false"/>
+                    <param name="middle" value="false"/>
+                    <param name="right" value="false"/>
+                    <param name="leftBottom" value="true"/>
+                    <param name="bottom" value="false"/>
+                    <param name="rightBottom" value="true"/>
+                </param>
             </params>
         </property>
     </properties>

--- a/tests/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoaderTest.php
+++ b/tests/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoaderTest.php
@@ -172,6 +172,67 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                             'type' => 'string',
                             'meta' => [],
                         ],
+                        [
+                            'name' => 'displayOptions',
+                            'value' => [
+                                [
+                                    'name' => 'leftTop',
+                                    'value' => true,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                                [
+                                    'name' => 'top',
+                                    'value' => false,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                                [
+                                    'name' => 'rightTop',
+                                    'value' => true,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                                [
+                                    'name' => 'left',
+                                    'value' => false,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                                [
+                                    'name' => 'middle',
+                                    'value' => false,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                                [
+                                    'name' => 'right',
+                                    'value' => false,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                                [
+                                    'name' => 'leftBottom',
+                                    'value' => true,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                                [
+                                    'name' => 'bottom',
+                                    'value' => false,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                                [
+                                    'name' => 'rightBottom',
+                                    'value' => true,
+                                    'type' => 'string',
+                                    'meta' => []
+                                ],
+                            ],
+                            'type' => 'collection',
+                            'meta' => [],
+                        ],
                     ],
                     'meta' => [],
                 ],


### PR DESCRIPTION
Booleans were not interpreted as booleans by the XmlLoader, this has been fixed.

__tasks:__

- [x] test coverage
- [x] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | fixes #1430 
| BC breaks        | `"true"` and `"false"` are not interpreted as strings anymore
| Documentation PR | none