### PR TITLE
Append SmartContent tags from website URL parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #1369 [SmartContent]    Extended SmartContent to be able to add tags from website URL
+    * FEATURE     #1369 [TagBundle]       Added TwigExtension to handle tags in twig templates
     * FEATURE     #1369 [ContentBundle]   Show icons in column navigation based on the user's permission
     * FEATURE     #1415 [ContentBundle]   Refactored SmartContent to use DataProvider to load content
     * BUGFIX      #1462 [Rest]            Fixed type of returned value for the Doctrine list builder count method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
-    * FEATURE     #1369 [SmartContent]    Extended SmartContent to be able to add tags from website URL
-    * FEATURE     #1369 [TagBundle]       Added TwigExtension to handle tags in twig templates
+    * FEATURE     #1512 [SmartContent]    Extended SmartContent to be able to add tags from website URL
+    * FEATURE     #1512 [TagBundle]       Added TwigExtension to handle tags in twig templates
     * FEATURE     #1369 [ContentBundle]   Show icons in column navigation based on the user's permission
     * FEATURE     #1415 [ContentBundle]   Refactored SmartContent to use DataProvider to load content
     * BUGFIX      #1462 [Rest]            Fixed type of returned value for the Doctrine list builder count method

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/smart_content.xml
@@ -44,6 +44,7 @@
             <argument type="service" id="sulu_content.smart_content.data_provider_pool"/>
             <argument type="service" id="sulu_tag.tag_manager"/>
             <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu_tag.tag_request_handler"/>
             <argument>%sulu.content.type.smart_content.template%</argument>
 
             <tag name="sulu.content.type" alias="smart_content"/>

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <parameter key="sulu_tag.tag_manager.class">Sulu\Bundle\TagBundle\Tag\TagManager</parameter>
         <parameter key="sulu_tag.tag_repository.class">Sulu\Bundle\TagBundle\Entity\TagRepository</parameter>
         <parameter key="sulu_tag.content.type.tag_list.class">Sulu\Bundle\TagBundle\Content\Types\TagList</parameter>
+        <parameter key="sulu_tag.tag_request_handler.class">Sulu\Component\Tag\Request\TagRequestHandler</parameter>
         <parameter key="sulu_tag.twig_extension.class">Sulu\Bundle\TagBundle\Twig\TagTwigExtension</parameter>
         <parameter key="sulu_tag.entity.tag">SuluTagBundle:Tag</parameter>
     </parameters>
@@ -32,9 +33,13 @@
             <argument>%sulu_tag.content.type.tag_list.template%</argument>
         </service>
 
+        <service id="sulu_tag.tag_request_handler" class="%sulu_tag.tag_request_handler.class%">
+            <argument type="service" id="request_stack"/>
+        </service>
+
         <service id="sulu_tag.twig_extension" class="%sulu_tag.twig_extension.class%">
             <argument type="service" id="sulu_tag.tag_manager"/>
-            <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu_tag.tag_request_handler"/>
 
             <tag name="twig.extension"/>
         </service>

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <parameter key="sulu_tag.tag_manager.class">Sulu\Bundle\TagBundle\Tag\TagManager</parameter>
         <parameter key="sulu_tag.tag_repository.class">Sulu\Bundle\TagBundle\Entity\TagRepository</parameter>
         <parameter key="sulu_tag.content.type.tag_list.class">Sulu\Bundle\TagBundle\Content\Types\TagList</parameter>
+        <parameter key="sulu_tag.twig_extension.class">Sulu\Bundle\TagBundle\Twig\TagTwigExtension</parameter>
         <parameter key="sulu_tag.entity.tag">SuluTagBundle:Tag</parameter>
     </parameters>
     <services>
@@ -30,5 +31,13 @@
             <argument type="service" id="sulu_tag.tag_manager"/>
             <argument>%sulu_tag.content.type.tag_list.template%</argument>
         </service>
+
+        <service id="sulu_tag.twig_extension" class="%sulu_tag.twig_extension.class%">
+            <argument type="service" id="sulu_tag.tag_manager"/>
+            <argument type="service" id="request_stack"/>
+
+            <tag name="twig.extension"/>
+        </service>
+
     </services>
 </container>

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
@@ -1,0 +1,143 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TagBundle\Tests\Unit\Twig;
+
+use Sulu\Bundle\TagBundle\Entity\Tag;
+use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
+use Sulu\Bundle\TagBundle\Twig\TagTwigExtension;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class TagTwigExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetTags()
+    {
+        $tag = new Tag();
+        $tag->setName('Test');
+
+        $tagManager = $this->prophesize(TagManagerInterface::class);
+        $requestStack = $this->prophesize(RequestStack::class);
+
+        $tagManager->findAll()->shouldBeCalled()->willReturn([$tag]);
+
+        $tagExtension = new TagTwigExtension($tagManager->reveal(), $requestStack->reveal());
+        $this->assertEquals([$tag], $tagExtension->getTagsFunction());
+    }
+
+    public function appendProvider()
+    {
+        return [
+            ['t', '/test', 'Sulu,Core', 'Sulu,Core,Test'],
+            ['tags', '/asdf', 'Sulu,Core', 'Sulu,Core,Test'],
+            ['t', '/asdf', 'Sulu,Core', 'Sulu,Core,Test'],
+            ['tags', '/test', 'Sulu,Core', 'Sulu,Core,Test'],
+            ['tags', '/test', 'Sulu,Test', 'Sulu,Test'],
+            ['tags', '/test', '', 'Test'],
+        ];
+    }
+
+    /**
+     * @dataProvider appendProvider
+     */
+    public function testAppendTagUrl($tagsParameter, $url, $tagsString, $expected)
+    {
+        $tag = new Tag();
+        $tag->setName('Test');
+
+        $tagManager = $this->prophesize(TagManagerInterface::class);
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = $this->prophesize(Request::class);
+
+        $requestReveal = $request->reveal();
+        $requestReveal->query = new ParameterBag([$tagsParameter => $tagsString]);
+        $requestStack->getCurrentRequest()->willReturn($requestReveal);
+        $request->get($tagsParameter, '')->willReturn($tagsString);
+        $request->getPathInfo()->willReturn($url);
+
+        $tagExtension = new TagTwigExtension($tagManager->reveal(), $requestStack->reveal());
+        $result = $tagExtension->appendTagUrlFunction($tag, $tagsParameter);
+
+        $this->assertEquals($url . '?' . $tagsParameter . '=' . urlencode($expected), $result);
+    }
+
+    public function setProvider()
+    {
+        return [
+            ['t', '/test', 'Sulu,Core', 'Test'],
+            ['tags', '/asdf', 'Sulu,Core', 'Test'],
+            ['t', '/asdf', 'Sulu,Core', 'Test'],
+            ['tags', '/test', 'Sulu,Core', 'Test'],
+            ['tags', '/test', 'Sulu,Test', 'Test'],
+            ['tags', '/test', '', 'Test'],
+        ];
+    }
+
+    /**
+     * @dataProvider setProvider
+     */
+    public function testSetTagUrl($tagsParameter, $url, $tagsString, $expected)
+    {
+        $tag = new Tag();
+        $tag->setName('Test');
+
+        $tagManager = $this->prophesize(TagManagerInterface::class);
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = $this->prophesize(Request::class);
+
+        $requestReveal = $request->reveal();
+        $requestReveal->query = new ParameterBag([$tagsParameter => $tagsString]);
+        $requestStack->getCurrentRequest()->willReturn($requestReveal);
+        $request->get($tagsParameter, '')->willReturn($tagsString);
+        $request->getPathInfo()->willReturn($url);
+
+        $tagExtension = new TagTwigExtension($tagManager->reveal(), $requestStack->reveal());
+        $result = $tagExtension->setTagUrlFunction($tag, $tagsParameter);
+
+        $this->assertEquals($url . '?' . $tagsParameter . '=' . urlencode($expected), $result);
+    }
+
+    public function clearProvider()
+    {
+        return [
+            ['t', '/test', 'Sulu,Core'],
+            ['t', '/asdf', 'Sulu,Core'],
+            ['tags', '/asdf', 'Sulu,Core'],
+            ['tags', '/test', 'Sulu,Core'],
+            ['tags', '/test', 'Sulu,Test'],
+            ['tags', '/test', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider clearProvider
+     */
+    public function testClearTagUrl($tagsParameter, $url, $tagsString)
+    {
+        $tag = new Tag();
+        $tag->setName('Test');
+
+        $tagManager = $this->prophesize(TagManagerInterface::class);
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = $this->prophesize(Request::class);
+
+        $requestReveal = $request->reveal();
+        $requestReveal->query = new ParameterBag([$tagsParameter => $tagsString]);
+        $requestStack->getCurrentRequest()->willReturn($requestReveal);
+        $request->get($tagsParameter, '')->willReturn($tagsString);
+        $request->getPathInfo()->willReturn($url);
+
+        $tagExtension = new TagTwigExtension($tagManager->reveal(), $requestStack->reveal());
+        $result = $tagExtension->clearTagUrlFunction($tagsParameter);
+
+        $this->assertEquals($url, $result);
+    }
+}

--- a/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TagBundle\Twig;
+
+use Sulu\Bundle\TagBundle\Entity\Tag;
+use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class TagTwigExtension extends \Twig_Extension
+{
+    /**
+     * @var TagManagerInterface
+     */
+    private $tagManager;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(TagManagerInterface $tagManager, RequestStack $requestStack)
+    {
+        $this->tagManager = $tagManager;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('sulu_tags', [$this, 'getTagsFunction']),
+            new \Twig_SimpleFunction('sulu_tag_url', [$this, 'setTagUrlFunction']),
+            new \Twig_SimpleFunction('sulu_tag_url_append', [$this, 'appendTagUrlFunction']),
+            new \Twig_SimpleFunction('sulu_tag_url_clear', [$this, 'clearTagUrlFunction']),
+        ];
+    }
+
+    /**
+     * @return Tag[]
+     */
+    public function getTagsFunction()
+    {
+        return $this->tagManager->findAll();
+    }
+
+    /**
+     * Extends current URL with given tag.
+     *
+     * @param Tag $tag will be included in the URL.
+     * @param string $tagsParameter GET parameter name.
+     *
+     * @return string
+     */
+    public function appendTagUrlFunction(Tag $tag, $tagsParameter = 'tags')
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        // extend comma separated list
+        $tags = $request->get($tagsParameter, '');
+        $tagsArray = array_merge(explode(',', $tags), [$tag->getName()]);
+        $tags = implode(',', array_unique($tagsArray));
+
+        // get all parameter and extend with new tags string
+        $query = $request->query->all();
+        $query = array_merge($query, [$tagsParameter => $tags]);
+
+        $queryString = http_build_query($query);
+
+        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+    }
+
+    /**
+     * Set tag to current URL.
+     *
+     * @param Tag $tag will be included in the URL.
+     * @param string $tagsParameter GET parameter name.
+     *
+     * @return string
+     */
+    public function setTagUrlFunction(Tag $tag, $tagsParameter = 'tags')
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        // get all parameter and extend with new tags string
+        $query = $request->query->all();
+        $query = array_merge($query, [$tagsParameter => $tag->getName()]);
+
+        $queryString = http_build_query($query);
+
+        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+    }
+
+    /**
+     * Remove tag from current URL.
+     *
+     * @param string $tagsParameter GET parameter name.
+     *
+     * @return string
+     */
+    public function clearTagUrlFunction($tagsParameter = 'tags')
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        // get all parameter and extend with new tags string
+        $query = $request->query->all();
+        unset($query[$tagsParameter]);
+
+        $queryString = http_build_query($query);
+
+        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sulu_tag';
+    }
+}

--- a/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
@@ -67,7 +67,7 @@ class TagTwigExtension extends \Twig_Extension
 
         // extend comma separated list
         $tags = $request->get($tagsParameter, '');
-        $tagsArray = array_merge(explode(',', $tags), [$tag->getName()]);
+        $tagsArray = array_filter(array_merge(explode(',', $tags), [$tag->getName()]));
         $tags = implode(',', array_unique($tagsArray));
 
         // get all parameter and extend with new tags string

--- a/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
@@ -12,7 +12,7 @@ namespace Sulu\Bundle\TagBundle\Twig;
 
 use Sulu\Bundle\TagBundle\Entity\Tag;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
 
 class TagTwigExtension extends \Twig_Extension
 {
@@ -22,14 +22,14 @@ class TagTwigExtension extends \Twig_Extension
     private $tagManager;
 
     /**
-     * @var RequestStack
+     * @var TagRequestHandlerInterface
      */
-    private $requestStack;
+    private $tagRequestHandler;
 
-    public function __construct(TagManagerInterface $tagManager, RequestStack $requestStack)
+    public function __construct(TagManagerInterface $tagManager, TagRequestHandlerInterface $tagRequestHandler)
     {
         $this->tagManager = $tagManager;
-        $this->requestStack = $requestStack;
+        $this->tagRequestHandler = $tagRequestHandler;
     }
 
     /**
@@ -63,20 +63,7 @@ class TagTwigExtension extends \Twig_Extension
      */
     public function appendTagUrlFunction(Tag $tag, $tagsParameter = 'tags')
     {
-        $request = $this->requestStack->getCurrentRequest();
-
-        // extend comma separated list
-        $tags = $request->get($tagsParameter, '');
-        $tagsArray = array_filter(array_merge(explode(',', $tags), [$tag->getName()]));
-        $tags = implode(',', array_unique($tagsArray));
-
-        // get all parameter and extend with new tags string
-        $query = $request->query->all();
-        $query = array_merge($query, [$tagsParameter => $tags]);
-
-        $queryString = http_build_query($query);
-
-        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+        return $this->tagRequestHandler->appendTagToUrl($tag, $tagsParameter);
     }
 
     /**
@@ -89,15 +76,7 @@ class TagTwigExtension extends \Twig_Extension
      */
     public function setTagUrlFunction(Tag $tag, $tagsParameter = 'tags')
     {
-        $request = $this->requestStack->getCurrentRequest();
-
-        // get all parameter and extend with new tags string
-        $query = $request->query->all();
-        $query = array_merge($query, [$tagsParameter => $tag->getName()]);
-
-        $queryString = http_build_query($query);
-
-        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+        return $this->tagRequestHandler->setTagToUrl($tag, $tagsParameter);
     }
 
     /**
@@ -109,15 +88,7 @@ class TagTwigExtension extends \Twig_Extension
      */
     public function clearTagUrlFunction($tagsParameter = 'tags')
     {
-        $request = $this->requestStack->getCurrentRequest();
-
-        // get all parameter and extend with new tags string
-        $query = $request->query->all();
-        unset($query[$tagsParameter]);
-
-        $queryString = http_build_query($query);
-
-        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+        return $this->tagRequestHandler->removeTagsFromUrl($tagsParameter);
     }
 
     /**

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -216,8 +216,12 @@ class ContentType extends ComplexContentType
         $filters = $property->getValue();
         $filters['excluded'] = [$property->getStructure()->getUuid()];
 
+        // default value of tags is an empty array
+        if (array_key_exists('tags', $filters)) {
+            $filters['tags'] = [];
+        }
+
         // extends selected filter with requested tags
-        $filters = array_merge(['tags' => []], $filters);
         $filters['tags'] = array_merge($this->getTags($params['tags_parameter']->getValue()), $filters['tags']);
 
         // resolve tags to id
@@ -331,7 +335,7 @@ class ContentType extends ComplexContentType
     }
 
     /**
-     * determine current page from current request.
+     * Determine current page from current request.
      *
      * @param string $pageParameter
      *
@@ -349,7 +353,7 @@ class ContentType extends ComplexContentType
     }
 
     /**
-     * determine tags from current request.
+     * Determine tags from current request.
      *
      * @param string $tagsParameter
      *

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -220,7 +220,7 @@ class ContentType extends ComplexContentType
         $filters['tags'] = array_merge($this->getTags($params['tags_parameter']->getValue()), $filters['tags']);
 
         // resolve tags to id
-        if (!empty($filters['tags'])) {
+        if (!empty($filters['tags']) && count($filters['tags']) > 0) {
             $filters['tags'] = $this->tagManager->resolveTagNames($filters['tags']);
         }
 

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -157,7 +157,7 @@ class ContentType extends ComplexContentType
 
         $defaults = [
             'page_parameter' => new PropertyParameter('page_parameter', 'p'),
-            'tag_parameter' => new PropertyParameter('tag_parameter', 'tag'),
+            'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
             'sorting' => new PropertyParameter('sorting', $configuration->getSorting(), 'collection'),
             'present_as' => new PropertyParameter('present_as', [], 'collection'),
             'has' => [
@@ -214,6 +214,10 @@ class ContentType extends ComplexContentType
         // prepare filters
         $filters = $property->getValue();
         $filters['excluded'] = [$property->getStructure()->getUuid()];
+
+        // extends selected filter with requested tags
+        $filters = array_merge(['tags' => []], $filters);
+        $filters['tags'] = array_merge($this->getTags($params['tags_parameter']->getValue()), $filters['tags']);
 
         // resolve tags to id
         if (!empty($filters['tags'])) {
@@ -341,5 +345,23 @@ class ContentType extends ComplexContentType
         }
 
         return intval($page);
+    }
+
+    /**
+     * determine tags from current request.
+     *
+     * @param string $tagsParameter
+     *
+     * @return string[]
+     */
+    private function getTags($tagsParameter)
+    {
+        if ($this->requestStack->getCurrentRequest() !== null) {
+            $tags = $this->requestStack->getCurrentRequest()->get($tagsParameter, '');
+        } else {
+            $tags = '';
+        }
+
+        return array_filter(explode(',', $tags));
     }
 }

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -156,6 +156,7 @@ class ContentType extends ComplexContentType
         $configuration = $provider->getConfiguration();
 
         $defaults = [
+            'provider' => new PropertyParameter('provider', 'content'),
             'page_parameter' => new PropertyParameter('page_parameter', 'p'),
             'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
             'sorting' => new PropertyParameter('sorting', $configuration->getSorting(), 'collection'),

--- a/src/Sulu/Component/Tag/Request/TagRequestHandler.php
+++ b/src/Sulu/Component/Tag/Request/TagRequestHandler.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Tag\Request;
+
+use Sulu\Bundle\TagBundle\Entity\Tag;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Handles tags in current request.
+ */
+class TagRequestHandler implements TagRequestHandlerInterface
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTags($tagsParameter = 'tags')
+    {
+        if ($this->requestStack->getCurrentRequest() !== null) {
+            $tags = $this->requestStack->getCurrentRequest()->get($tagsParameter, '');
+        } else {
+            $tags = '';
+        }
+
+        return array_map(
+            function ($item) {
+                return trim($item);
+            },
+            array_filter(explode(',', $tags))
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function appendTagToUrl(Tag $tag, $tagsParameter = 'tags')
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        // extend comma separated list
+        $tags = $request->get($tagsParameter, '');
+        $tagsArray = array_filter(array_merge(explode(',', $tags), [$tag->getName()]));
+        $tags = implode(',', array_unique($tagsArray));
+
+        // get all parameter and extend with new tags string
+        $query = $request->query->all();
+        $query = array_merge($query, [$tagsParameter => $tags]);
+
+        $queryString = http_build_query($query);
+
+        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTagToUrl(Tag $tag, $tagsParameter = 'tags')
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        // get all parameter and extend with new tags string
+        $query = $request->query->all();
+        $query = array_merge($query, [$tagsParameter => $tag->getName()]);
+
+        $queryString = http_build_query($query);
+
+        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeTagsFromUrl($tagsParameter = 'tags')
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        // get all parameter and extend with new tags string
+        $query = $request->query->all();
+        unset($query[$tagsParameter]);
+
+        $queryString = http_build_query($query);
+
+        return $request->getPathInfo() . (strlen($queryString) > 0 ? '?' . $queryString : '');
+    }
+}

--- a/src/Sulu/Component/Tag/Request/TagRequestHandlerInterface.php
+++ b/src/Sulu/Component/Tag/Request/TagRequestHandlerInterface.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Tag\Request;
+
+use Sulu\Bundle\TagBundle\Entity\Tag;
+
+/**
+ * Handles tags in current request.
+ */
+interface TagRequestHandlerInterface
+{
+    /**
+     * Determine tags from current request.
+     *
+     * @param string $tagsParameter
+     *
+     * @return string[]
+     */
+    public function getTags($tagsParameter = 'tags');
+
+    /**
+     * Extends current URL with given tag.
+     *
+     * @param Tag $tag will be included in the URL.
+     * @param string $tagsParameter GET parameter name.
+     *
+     * @return string
+     */
+    public function appendTagToUrl(Tag $tag, $tagsParameter = 'tags');
+
+    /**
+     * Set tag to current URL.
+     *
+     * @param Tag $tag will be included in the URL.
+     * @param string $tagsParameter GET parameter name.
+     *
+     * @return string
+     */
+    public function setTagToUrl(Tag $tag, $tagsParameter = 'tags');
+
+    /**
+     * Remove tag from current URL.
+     *
+     * @param string $tagsParameter GET parameter name.
+     *
+     * @return string
+     */
+    public function removeTagsFromUrl($tagsParameter = 'tags');
+}

--- a/tests/Sulu/Component/SmartContent/ContentTypeTest.php
+++ b/tests/Sulu/Component/SmartContent/ContentTypeTest.php
@@ -310,7 +310,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'dataSource' => 'some-uuid',
                 'page' => 1,
                 'hasNextPage' => true,
-                'excluded' => ['123-123-123']
+                'excluded' => ['123-123-123'],
             ],
             [
                 'provider' => new PropertyParameter('provider', 'content'),

--- a/tests/Sulu/Component/SmartContent/ContentTypeTest.php
+++ b/tests/Sulu/Component/SmartContent/ContentTypeTest.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\SmartContent\Configuration\ProviderConfiguration;
 use Sulu\Component\SmartContent\ContentType as SmartContent;
+use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -49,6 +50,11 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
     private $request;
 
     /**
+     * @var TagRequestHandlerInterface
+     */
+    private $tagRequestHandler;
+
+    /**
      * @var DataProviderPoolInterface
      */
     private $dataProviderPool;
@@ -68,7 +74,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $this->dataProviderPool->add('content', $this->contentDataProvider->reveal());
 
         $this->tagManager = $this->getMockForAbstractClass(
-            'Sulu\Bundle\TagBundle\Tag\TagManagerInterface',
+            TagManagerInterface::class,
             [],
             '',
             false,
@@ -77,17 +83,21 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ['resolveTagIds', 'resolveTagNames']
         );
 
-        $this->requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
-        $this->request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
+        $this->requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
+        $this->request = $this->getMockBuilder(Request::class)->getMock();
 
         $this->requestStack->expects($this->any())->method('getCurrentRequest')->will(
             $this->returnValue($this->request)
         );
 
+        $this->tagRequestHandler = $this->prophesize(TagRequestHandlerInterface::class);
+        $this->tagRequestHandler->getTags('tags')->willReturn([]);
+
         $this->smartContent = new SmartContent(
             $this->dataProviderPool,
             $this->tagManager,
             $this->requestStack,
+            $this->tagRequestHandler->reveal(),
             'SuluContentBundle:Template:content-types/smart_content.html.twig'
         );
 
@@ -337,12 +347,9 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
 
         $structure->expects($this->any())->method('getUuid')->will($this->returnValue('123-123-123'));
 
-        $this->request->expects($this->at(1))->method('get')
+        $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'), $this->equalTo(1), $this->equalTo(false))
             ->willReturn(1);
-        $this->request->expects($this->at(0))->method('get')
-            ->with($this->equalTo('tags'), $this->equalTo(''), $this->equalTo(false))
-            ->willReturn('');
 
         $viewData = $this->smartContent->getViewData($property);
 
@@ -392,12 +399,9 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             'Sulu\Component\Content\Compat\StructureInterface'
         );
 
-        $this->request->expects($this->at(1))->method('get')
+        $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'), $this->equalTo(1), $this->equalTo(false))
             ->willReturn(1);
-        $this->request->expects($this->at(0))->method('get')
-            ->with($this->equalTo('tags'), $this->equalTo(''), $this->equalTo(false))
-            ->willReturn('');
 
         $property->expects($this->exactly(1))->method('getValue')
             ->will($this->returnValue(['dataSource' => '123-123-123']));
@@ -477,12 +481,9 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             'Sulu\Component\Content\Compat\StructureInterface'
         );
 
-        $this->request->expects($this->at(1))->method('get')
+        $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'), $this->equalTo(1), $this->equalTo(false))
             ->willReturn($page);
-        $this->request->expects($this->at(0))->method('get')
-            ->with($this->equalTo('tags'), $this->equalTo(''), $this->equalTo(false))
-            ->willReturn('');
 
         $config = ['limitResult' => $limitResult, 'dataSource' => $uuid];
 
@@ -553,12 +554,9 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             'Sulu\Component\Content\Compat\StructureInterface'
         );
 
-        $this->request->expects($this->at(1))->method('get')
+        $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'), $this->equalTo(1), $this->equalTo(false))
             ->willReturn($page);
-        $this->request->expects($this->at(0))->method('get')
-            ->with($this->equalTo('tags'), $this->equalTo(''), $this->equalTo(false))
-            ->willReturn('');
 
         $config = ['limitResult' => $limitResult, 'dataSource' => $uuid];
 

--- a/tests/Sulu/Component/SmartContent/ContentTypeTest.php
+++ b/tests/Sulu/Component/SmartContent/ContentTypeTest.php
@@ -313,6 +313,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'excluded' => ['123-123-123']
             ],
             [
+                'provider' => new PropertyParameter('provider', 'content'),
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
                 'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
@@ -409,6 +410,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $this->contentDataProvider->resolveFilters(
             ['tags' => [], 'dataSource' => '123-123-123', 'excluded' => ['123-123-123']],
             [
+                'provider' => new PropertyParameter('provider', 'content'),
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
                 'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
@@ -492,6 +494,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'excluded' => [$uuid],
             ],
             [
+                'provider' => new PropertyParameter('provider', 'content'),
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
                 'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
@@ -569,6 +572,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'excluded' => [$uuid],
             ],
             [
+                'provider' => new PropertyParameter('provider', 'content'),
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
                 'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
@@ -657,6 +661,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'excluded' => ['123-123-123'],
             ],
             [
+                'provider' => new PropertyParameter('provider', 'content'),
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
                 'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),

--- a/tests/Sulu/Component/SmartContent/ContentTypeTest.php
+++ b/tests/Sulu/Component/SmartContent/ContentTypeTest.php
@@ -305,10 +305,16 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($structure));
 
         $this->contentDataProvider->resolveFilters(
-            ['dataSource' => 'some-uuid', 'page' => 1, 'hasNextPage' => true, 'excluded' => ['123-123-123']],
+            [
+                'tags' => [],
+                'dataSource' => 'some-uuid',
+                'page' => 1,
+                'hasNextPage' => true,
+                'excluded' => ['123-123-123']
+            ],
             [
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
-                'tag_parameter' => new PropertyParameter('tag_parameter', 'tag'),
+                'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
                 'present_as' => new PropertyParameter('present_as', [], 'collection'),
                 'has' => [
@@ -330,7 +336,12 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
 
         $structure->expects($this->any())->method('getUuid')->will($this->returnValue('123-123-123'));
 
-        $this->request->expects($this->any())->method('get')->will($this->returnValue(1));
+        $this->request->expects($this->at(1))->method('get')
+            ->with($this->equalTo('p'), $this->equalTo(1), $this->equalTo(false))
+            ->willReturn(1);
+        $this->request->expects($this->at(0))->method('get')
+            ->with($this->equalTo('tags'), $this->equalTo(''), $this->equalTo(false))
+            ->willReturn('');
 
         $viewData = $this->smartContent->getViewData($property);
 
@@ -358,7 +369,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
     public function testGetReferencedUuids()
     {
         $property = $this->getContentDataProperty(
-            ['dataSource' => '123-123-123', 'referencedUuids' => [1, 2, 3, 4, 5, 6]]
+            ['tags' => [], 'dataSource' => '123-123-123', 'referencedUuids' => [1, 2, 3, 4, 5, 6]]
         );
         $uuids = $this->smartContent->getReferencedUuids($property);
 
@@ -380,7 +391,12 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             'Sulu\Component\Content\Compat\StructureInterface'
         );
 
-        $this->request->expects($this->any())->method('get')->will($this->returnValue(1));
+        $this->request->expects($this->at(1))->method('get')
+            ->with($this->equalTo('p'), $this->equalTo(1), $this->equalTo(false))
+            ->willReturn(1);
+        $this->request->expects($this->at(0))->method('get')
+            ->with($this->equalTo('tags'), $this->equalTo(''), $this->equalTo(false))
+            ->willReturn('');
 
         $property->expects($this->exactly(1))->method('getValue')
             ->will($this->returnValue(['dataSource' => '123-123-123']));
@@ -391,10 +407,10 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($structure));
 
         $this->contentDataProvider->resolveFilters(
-            ['dataSource' => '123-123-123', 'excluded' => ['123-123-123']],
+            ['tags' => [], 'dataSource' => '123-123-123', 'excluded' => ['123-123-123']],
             [
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
-                'tag_parameter' => new PropertyParameter('tag_parameter', 'tag'),
+                'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
                 'present_as' => new PropertyParameter('present_as', [], 'collection'),
                 'has' => [
@@ -459,19 +475,25 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             'Sulu\Component\Content\Compat\StructureInterface'
         );
 
-        $this->request->expects($this->any())->method('get')->will($this->returnValue($page));
+        $this->request->expects($this->at(1))->method('get')
+            ->with($this->equalTo('p'), $this->equalTo(1), $this->equalTo(false))
+            ->willReturn($page);
+        $this->request->expects($this->at(0))->method('get')
+            ->with($this->equalTo('tags'), $this->equalTo(''), $this->equalTo(false))
+            ->willReturn('');
 
         $config = ['limitResult' => $limitResult, 'dataSource' => $uuid];
 
         $this->contentDataProvider->resolveFilters(
             [
+                'tags' => [],
                 'limitResult' => $limitResult,
                 'dataSource' => $uuid,
                 'excluded' => [$uuid],
             ],
             [
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
-                'tag_parameter' => new PropertyParameter('tag_parameter', 'tag'),
+                'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
                 'present_as' => new PropertyParameter('present_as', [], 'collection'),
                 'has' => [
@@ -528,12 +550,18 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             'Sulu\Component\Content\Compat\StructureInterface'
         );
 
-        $this->request->expects($this->any())->method('get')->will($this->returnValue($page));
+        $this->request->expects($this->at(1))->method('get')
+            ->with($this->equalTo('p'), $this->equalTo(1), $this->equalTo(false))
+            ->willReturn($page);
+        $this->request->expects($this->at(0))->method('get')
+            ->with($this->equalTo('tags'), $this->equalTo(''), $this->equalTo(false))
+            ->willReturn('');
 
         $config = ['limitResult' => $limitResult, 'dataSource' => $uuid];
 
         $this->contentDataProvider->resolveFilters(
             [
+                'tags' => [],
                 'limitResult' => $limitResult,
                 'dataSource' => $uuid,
                 'page' => $page,
@@ -542,7 +570,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
-                'tag_parameter' => new PropertyParameter('tag_parameter', 'tag'),
+                'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
                 'present_as' => new PropertyParameter('present_as', [], 'collection'),
                 'has' => [
@@ -624,12 +652,13 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->contentDataProvider->resolveFilters(
             [
+                'tags' => [],
                 'dataSource' => '123-123-123',
                 'excluded' => ['123-123-123'],
             ],
             [
                 'page_parameter' => new PropertyParameter('page_parameter', 'p'),
-                'tag_parameter' => new PropertyParameter('tag_parameter', 'tag'),
+                'tags_parameter' => new PropertyParameter('tags_parameter', 'tags'),
                 'sorting' => new PropertyParameter('sorting', [], 'collection'),
                 'present_as' => new PropertyParameter('present_as', [], 'collection'),
                 'has' => [


### PR DESCRIPTION
Ability to add tags from the website URL to the filters.

__tasks:__

- [x] test coverage
- [ ] gather feedback for my changes
- [x] submit changes to the documentation

Related PR: https://github.com/sulu-io/sulu-standard/pull/486

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | https://github.com/sulu-io/sulu-docs/pull/64