### PR TITLE
removed index specific code from content

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Admin/ContentAdmin.php
+++ b/src/Sulu/Bundle/ContentBundle/Admin/ContentAdmin.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\ContentBundle\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Navigation\Navigation;
 use Sulu\Bundle\AdminBundle\Navigation\NavigationItem;
+use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
@@ -31,6 +32,11 @@ class ContentAdmin extends Admin
     private $securityChecker;
 
     /**
+     * @var SessionManagerInterface
+     */
+    private $sessionManager;
+
+    /**
      * The prefix for the security context, the key of the webspace has to be appended.
      *
      * @var string
@@ -40,10 +46,12 @@ class ContentAdmin extends Admin
     public function __construct(
         WebspaceManagerInterface $webspaceManager,
         SecurityCheckerInterface $securityChecker,
+        SessionManagerInterface $sessionManager,
         $title
     ) {
         $this->webspaceManager = $webspaceManager;
         $this->securityChecker = $securityChecker;
+        $this->sessionManager = $sessionManager;
 
         $rootNavigationItem = new NavigationItem($title);
 
@@ -57,9 +65,11 @@ class ContentAdmin extends Admin
                 $webspaceItem = new NavigationItem($webspace->getName());
                 $webspaceItem->setIcon('bullseye');
 
+                $indexUuid = $this->sessionManager->getContentNode($webspace->getKey())->getIdentifier();
+
                 $indexPageItem = new NavigationItem('navigation.webspaces.index-page');
                 $indexPageItem->setAction(
-                    'content/contents/' . $webspace->getKey() . '/edit:index/details'
+                    'content/contents/' . $webspace->getKey() . '/edit:' . $indexUuid . '/details'
                 );
                 $webspaceItem->addChild($indexPageItem);
 

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -21,7 +21,6 @@ use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\Content\Mapper\ContentMapperRequest;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
-use Sulu\Component\Rest\Exception\InvalidArgumentException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Rest\RestController;
@@ -371,10 +370,6 @@ class NodeController extends RestController
      */
     public function putAction(Request $request, $uuid)
     {
-        if ($uuid === 'index') {
-            return $this->putIndex($request);
-        }
-
         $language = $this->getLanguage($request);
         $webspace = $this->getWebspace($request);
         $template = $this->getRequestParameter($request, 'template', true);
@@ -406,48 +401,6 @@ class NodeController extends RestController
         return $this->handleView(
             $this->view($result)
         );
-    }
-
-    /**
-     * put index page.
-     *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    private function putIndex(Request $request)
-    {
-        $language = $this->getLanguage($request);
-        $webspace = $this->getWebspace($request);
-        $template = $this->getRequestParameter($request, 'template', true);
-        $isShadow = $this->getRequestParameter($request, 'shadowOn', false);
-        $shadowBaseLanguage = $this->getRequestParameter($request, 'shadowBaseLanguage', null);
-
-        $data = $request->request->all();
-
-        try {
-            if (isset($data['url']) && $data['url'] != '/') {
-                throw new InvalidArgumentException('Content', 'url', 'url of index page can not be changed');
-            }
-
-            $result = $this->getRepository()->saveIndexNode(
-                $data,
-                $template,
-                $webspace,
-                $language,
-                $this->getUser()->getId(),
-                $isShadow,
-                $shadowBaseLanguage
-            );
-            $view = $this->view($result);
-        } catch (RestException $ex) {
-            $view = $this->view(
-                $ex->toArray(),
-                400
-            );
-        }
-
-        return $this->handleView($view);
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/PreviewController.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\ContentBundle\Controller;
 
 use Sulu\Bundle\ContentBundle\Preview\PreviewInterface;
-use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -50,13 +49,6 @@ class PreviewController extends Controller
 
         $webspaceKey = $this->getWebspaceKey($request);
         $locale = $this->getLanguageCode($request);
-
-        if ($contentUuid === 'index') {
-            /** @var ContentMapperInterface $contentMapper */
-            $contentMapper = $this->get('sulu.content.mapper');
-            $startPage = $contentMapper->loadStartPage($webspaceKey, $locale);
-            $contentUuid = $startPage->getUuid();
-        }
 
         if (!$preview->started($uid, $contentUuid, $webspaceKey, $locale)) {
             $preview->start($uid, $contentUuid, $webspaceKey, $locale);

--- a/src/Sulu/Bundle/ContentBundle/Preview/PreviewMessageHandler.php
+++ b/src/Sulu/Bundle/ContentBundle/Preview/PreviewMessageHandler.php
@@ -189,11 +189,6 @@ class PreviewMessageHandler implements MessageHandlerInterface
             throw new MissingParameterException('content');
         }
         $contentUuid = $msg['content'];
-        // filter index page
-        if ($contentUuid === 'index') {
-            $startPage = $this->contentMapper->loadStartPage($webspaceKey, $locale);
-            $contentUuid = $startPage->getUuid();
-        }
         $context->set('content', $contentUuid);
 
         // init message vars

--- a/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
@@ -207,32 +207,6 @@ class NodeRepository implements NodeRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function saveIndexNode(
-        $data,
-        $templateKey,
-        $webspaceKey,
-        $languageCode,
-        $userId,
-        $isShadow = false,
-        $shadowBaseLanguage = null
-    ) {
-        $structure = $this->getMapper()->saveStartPage(
-            $data,
-            $templateKey,
-            $webspaceKey,
-            $languageCode,
-            $userId,
-            true,
-            $isShadow,
-            $shadowBaseLanguage
-        );
-
-        return $this->prepareNode($structure, $webspaceKey, $languageCode);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function deleteNode($uuid, $webspaceKey)
     {
         // TODO remove third parameter, and ask in UI if referenced node should be deleted

--- a/src/Sulu/Bundle/ContentBundle/Repository/NodeRepositoryInterface.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/NodeRepositoryInterface.php
@@ -148,29 +148,6 @@ interface NodeRepositoryInterface
     );
 
     /**
-     * save start page of given portal.
-     *
-     * @param array  $data
-     * @param string $templateKey
-     * @param string $webspaceKey
-     * @param string $languageCode
-     * @param int    $userId
-     * @param bool   $isShadow
-     * @param string $shadowBaseLanguage
-     *
-     * @return array
-     */
-    public function saveIndexNode(
-        $data,
-        $templateKey,
-        $webspaceKey,
-        $languageCode,
-        $userId,
-        $isShadow = false,
-        $shadowBaseLanguage = null
-    );
-
-    /**
      * removes given node.
      *
      * @param string $uuid

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
@@ -19,6 +19,7 @@
             <tag name="sulu.context" context="admin"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_security.security_checker"/>
+            <argument type="service" id="sulu.phpcr.session"/>
             <argument>%sulu_admin.name%</argument>
         </service>
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/form/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/form/main.js
@@ -317,9 +317,6 @@ define(['sulucontent/components/content/preview/main'], function(Preview) {
                     }.bind(this));
             }
 
-            if (this.options.id === 'index') {
-                this.sandbox.dom.remove('#show-in-navigation-container');
-            }
             this.sandbox.dom.attr('#show-in-navigation', 'checked', data.navigation);
 
             return initialize;
@@ -438,17 +435,12 @@ define(['sulucontent/components/content/preview/main'], function(Preview) {
         },
 
         submit: function() {
-            this.sandbox.logger.log('save Model');
             var data;
 
             if (this.sandbox.form.validate(this.formId)) {
                 data = this.sandbox.form.getData(this.formId);
 
-                if (this.options.id === 'index') {
-                    data.navigation = true;
-                } else if (!!this.sandbox.dom.find('#show-in-navigation', this.$el).length) {
-                    data.navigation = this.sandbox.dom.prop('#show-in-navigation', 'checked');
-                }
+                data.navigation = this.sandbox.dom.prop('#show-in-navigation', 'checked');
 
                 this.sandbox.logger.log('data', data);
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
@@ -77,6 +77,10 @@ define([
             ].join(''),
 
             previewUrl: '<%= url %><%= uuid %>/render?webspace=<%= webspace %>&language=<%= language %>'
+        },
+
+        isHomeDocument = function(data) {
+            return data.url === '/';
         };
 
     return {
@@ -209,11 +213,6 @@ define([
                 this.sandbox.sulu.saveUserSetting(CONTENT_LANGUAGE, item.id);
                 if (this.options.display !== 'column') {
                     var data = this.content.toJSON();
-
-                    // if there is a index id this should be after reload
-                    if (this.options.id === 'index') {
-                        data.id = this.options.id;
-                    }
 
                     if (!!data.id) {
                         this.sandbox.emit('sulu.content.contents.load', data, this.options.webspace, item.id);
@@ -547,6 +546,7 @@ define([
                 this.options.language,
                 this.options.parent,
                 this.state,
+                (isHomeDocument(data) ? 'home' : null),
                 null, {
                     // on success save contents id
                     success: function(response) {
@@ -656,12 +656,10 @@ define([
                         (this.options.content !== 'settings' && this.data.shadowOn === true) ||
                         (this.options.content === 'content' && this.data.nodeType !== TYPE_CONTENT)
                     ) {
-                        var id = (this.options.id === 'index' ? this.options.id : data.id);
-
                         this.sandbox.emit(
                             'sulu.router.navigate',
                             'content/contents/' + this.options.webspace +
-                            '/' + this.options.language + '/edit:' + id + '/settings'
+                            '/' + this.options.language + '/edit:' + data.id + '/settings'
                         );
                     }
                 }
@@ -1018,8 +1016,7 @@ define([
                 this.headerInitialized.resolve();
             }.bind(this));
 
-            var noBack = (this.options.id === 'index'),
-                length, concreteLanguages = [],
+            var length, concreteLanguages = [],
                 def = this.sandbox.data.deferred();
 
             this.loadDataDeferred.then(function() {
@@ -1078,7 +1075,7 @@ define([
                     }
 
                     header = {
-                        noBack: noBack,
+                        noBack: isHomeDocument(this.data),
 
                         tabs: {
                             url: navigationUrl
@@ -1133,7 +1130,7 @@ define([
                                     items: [
                                         {
                                             title: this.sandbox.translate('toolbar.delete'),
-                                            disabled: (this.options.id === 'index'), // disable delete button if startpage (index)
+                                            disabled: isHomeDocument(this.data),
                                             callback: function() {
                                                 this.sandbox.emit('sulu.content.content.delete', this.data.id);
                                             }.bind(this)

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/resource-locator/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/resource-locator/main.js
@@ -26,7 +26,14 @@ define([], function() {
         },
 
         skeleton = function(options) {
-            if (options.contentId !== 'index') {
+            if (options.hasOwnProperty('value') && options.value === '/') {
+                return [
+                    '<div class="resource-locator">',
+                    '   <span id="' + options.ids.url + '" class="grey-font">', (!!options.url) ? options.url : '', '</span>',
+                    '   <span id="' + options.ids.tree + '" class="grey-font"></span>',
+                    '</div>'
+                ].join('');
+            } else {
                 return [
                     '<div class="resource-locator">',
                     '   <span id="' + options.ids.url + '" class="grey-font">', (!!options.url) ? options.url : '', '</span>',
@@ -37,13 +44,6 @@ define([], function() {
                     '       <span>', options.showHistoryText, '</span>',
                     '   </span>',
                     '   <div class="loader" id="', options.ids.loader, '"></div>',
-                    '</div>'
-                ].join('');
-            } else {
-                return [
-                    '<div class="resource-locator">',
-                    '   <span id="' + options.ids.url + '" class="grey-font">', (!!options.url) ? options.url : '', '</span>',
-                    '   <span id="' + options.ids.tree + '" class="grey-font"></span>',
                     '</div>'
                 ].join('');
             }

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/main.js
@@ -38,12 +38,7 @@ define(['config'], function(Config) {
             
             sandbox.urlManager.setUrl('page', 
                 function(data) {
-                    if (data.url === '/') {
-                        // startpage
-                        return 'content/contents/<%= webspace %>/<%= locale %>/edit:index/details';
-                    } else {
-                        return 'content/contents/<%= webspace %>/<%= locale %>/edit:<%= id %>/content';
-                    }
+                    return 'content/contents/<%= webspace %>/<%= locale %>/edit:<%= id %>/content';
                 },
                 function(data) {
                     return {

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/model/content.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/model/content.js
@@ -22,8 +22,18 @@ define([
             return this.save.call(this, attributes, options);
         },
 
-        fullSave: function(template, webspace, language, parent, state, attributes, options) {
-            options = _.defaults((options || {}), {url: this.urlRoot + (this.get('id') !== undefined ? '/' + this.get('id') : '') + '?webspace=' + webspace + '&language=' + language + '&template=' + template + (!!parent ? '&parent=' + parent : '') + (!!state ? '&state=' + state : '')});
+        fullSave: function(template, webspace, language, parent, state, type, attributes, options) {
+            options = _.defaults(
+                (options || {}),
+                {
+                    url: this.urlRoot + (this.get('id') !== undefined ? '/' + this.get('id') : '')
+                        + '?webspace=' + webspace
+                        + '&language=' + language
+                        + '&template=' + template
+                        + (!!type ? '&type=' + type : '')
+                        + (!!parent ? '&parent=' + parent : '')
+                        + (!!state ? '&state=' + state : '')
+                });
 
             return this.save.call(this, attributes, options);
         },
@@ -41,8 +51,7 @@ define([
         },
 
         defaults: function() {
-            return {
-            };
+            return {};
         }
     });
 });

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/validation/types/resourceLocator.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/validation/types/resourceLocator.js
@@ -29,7 +29,7 @@ define([
                 },
 
                 needsValidation: function() {
-                    return this.$el.data('auraContentId') !== 'index';
+                    return this.$el.find('input').length > 0;
                 },
 
                 validate: function() {

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TagBundle\Entity\Tag;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Document\RedirectType;
+use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
@@ -938,8 +939,6 @@ class NodeControllerTest extends SuluTestCase
     {
         $client = $this->createAuthenticatedClient();
         $data = $this->buildTree();
-        $mapper = self::$kernel->getContainer()->get('sulu.content.mapper');
-        $mapper->saveStartPage(['title' => 'Start Page'], 'default', 'sulu_io', 'en', 1);
 
         $client->request('GET', '/api/nodes/' . $data[4]['id'] . '?breadcrumb=true&webspace=sulu_io&language=en');
 
@@ -951,7 +950,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals($data[4]['article'], $response['article']);
 
         $this->assertEquals(3, count($response['breadcrumb']));
-        $this->assertEquals('Start Page', $response['breadcrumb'][0]['title']);
+        $this->assertEquals('Homepage', $response['breadcrumb'][0]['title']);
         $this->assertEquals('test2', $response['breadcrumb'][1]['title']);
         $this->assertEquals('test4', $response['breadcrumb'][2]['title']);
     }
@@ -1456,7 +1455,20 @@ class NodeControllerTest extends SuluTestCase
         /** @var ContentMapperInterface $mapper */
         $mapper = self::$kernel->getContainer()->get('sulu.content.mapper');
 
-        $mapper->saveStartPage(['title' => 'Start Page'], 'default', 'sulu_io', 'de', 1);
+        $mapper->save(
+            ['title' => 'Start Page'],
+            'default',
+            'sulu_io',
+            'de',
+            1,
+            true,
+            $this->getContainer()->get('sulu.phpcr.session')->getContentNode('sulu_io')->getIdentifier(),
+            null,
+            WorkflowStage::PUBLISHED,
+            null,
+            null,
+            'home'
+        );
 
         $client = $this->createAuthenticatedClient();
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Repository/NodeRepositoryTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Repository/NodeRepositoryTest.php
@@ -158,25 +158,6 @@ class NodeRepositoryTest extends SuluTestCase
         $this->assertEquals('/asdf', $result['url']);
     }
 
-    public function testIndexNode()
-    {
-        $data = [
-            'title' => 'Testtitle',
-            'url' => '/',
-        ];
-        $this->nodeRepository->saveIndexNode(
-            $data,
-            'overview',
-            'sulu_io',
-            'en',
-            1
-        );
-
-        $index = $this->nodeRepository->getIndexNode('sulu_io', 'en');
-
-        $this->assertEquals('Testtitle', $index['title']);
-    }
-
     public function testGetWebspaceNode()
     {
         $result = $this->nodeRepository->getWebspaceNode('sulu_io', 'en');

--- a/src/Sulu/Bundle/SearchBundle/Resources/public/js/components/search-results/main.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/public/js/components/search-results/main.js
@@ -49,7 +49,6 @@ define([
             this.options = this.sandbox.util.extend(true, {}, defaults, this.options);
             this.mainTemplate = this.sandbox.util.template(mainTemplate);
             this.searchResultsTemplate = this.sandbox.util.template(searchResultsTemplate);
-            this.dropDownEntries = [];
             this.enabledCategories = [];
             this.categories = {};
             this.categoriesStore = {};
@@ -78,9 +77,18 @@ define([
          */
         bindEvents: function() {
             this.sandbox.on('sulu.data-overlay.show', this.focusInput.bind(this));
-            this.sandbox.on('sulu.dropdown-input.' + this.dropDownInputInstance + '.action', this.dropDownInputActionHandler.bind(this));
-            this.sandbox.on('sulu.dropdown-input.' + this.dropDownInputInstance + '.clear', this.dropDownInputClearHandler.bind(this));
-            this.sandbox.on('sulu.dropdown-input.' + this.dropDownInputInstance + '.change', this.dropDownInputActionHandler.bind(this));
+            this.sandbox.on(
+                'sulu.dropdown-input.' + this.dropDownInputInstance + '.action',
+                this.dropDownInputActionHandler.bind(this)
+            );
+            this.sandbox.on(
+                'sulu.dropdown-input.' + this.dropDownInputInstance + '.clear',
+                this.dropDownInputClearHandler.bind(this)
+            );
+            this.sandbox.on(
+                'sulu.dropdown-input.' + this.dropDownInputInstance + '.change',
+                this.dropDownInputActionHandler.bind(this)
+            );
         },
 
         /**
@@ -387,7 +395,11 @@ define([
         },
 
         updateTotals: function(data) {
-            this.sandbox.emit('sulu.search-totals.' + this.searchTotalsInstanceName + '.update', this.totals, this.state.category);
+            this.sandbox.emit(
+                'sulu.search-totals.' + this.searchTotalsInstanceName + '.update',
+                this.totals,
+                this.state.category
+            );
         },
 
         /**

--- a/src/Sulu/Bundle/SnippetBundle/Resources/public/js/components/snippet/main.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/public/js/components/snippet/main.js
@@ -64,11 +64,6 @@ define([
                 this.sandbox.sulu.saveUserSetting(CONTENT_LANGUAGE, item.localization);
                 var data = this.model.toJSON();
 
-                // if there is a index id this should be after reload
-                if (this.options.id === 'index') {
-                    data.id = this.options.id;
-                }
-
                 if (this.type === 'edit') {
                     this.sandbox.emit('sulu.snippets.snippet.load', data.id, item.localization);
                 } else if (this.type === 'add') {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
@@ -109,8 +109,6 @@ class NavigationTest extends SuluTestCase
             ],
         ];
 
-        $this->mapper->saveStartPage(['title' => 'Startpage', 'url' => '/'], 'simple', 'sulu_io', 'en', 1);
-
         $data['news'] = $this->mapper->save(
             $data['news'],
             'simple',
@@ -355,7 +353,7 @@ class NavigationTest extends SuluTestCase
         $this->assertEquals(3, count($breadcrumb));
 
         // startpage has no title
-        $this->assertEquals('Startpage', $breadcrumb[0]->getTitle());
+        $this->assertEquals('Homepage', $breadcrumb[0]->getTitle());
         $this->assertEquals('/', $breadcrumb[0]->getUrl());
         $this->assertEquals('News', $breadcrumb[1]->getTitle());
         $this->assertEquals('/news', $breadcrumb[1]->getUrl());

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -302,37 +302,6 @@ class ContentMapper implements ContentMapperInterface
         return $structure;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function saveStartPage(
-        $data,
-        $templateKey,
-        $webspaceKey,
-        $locale,
-        $userId,
-        $partialUpdate = true,
-        $isShadow = null,
-        $shadowBaseLanguage = null
-    ) {
-        $uuid = $this->inspector->getUuid($this->getContentDocument($webspaceKey, $locale));
-
-        return $this->save(
-            $data,
-            $templateKey,
-            $webspaceKey,
-            $locale,
-            $userId,
-            $partialUpdate,
-            $uuid,
-            null,
-            WorkflowStage::PUBLISHED,
-            $isShadow,
-            $shadowBaseLanguage,
-            'home'
-        );
-    }
-
     public function loadByParent(
         $uuid,
         $webspaceKey,
@@ -1134,20 +1103,6 @@ class ContentMapper implements ContentMapperInterface
         }
 
         return $document;
-    }
-
-    private function filterDocuments($documents, $options)
-    {
-        $collection = [];
-        foreach ($documents as $document) {
-            if ($this->optionsShouldExcludeDocument($document, $options)) {
-                continue;
-            }
-
-            $collection[] = $document;
-        }
-
-        return $collection;
     }
 
     private function optionsShouldExcludeDocument($document, array $options = null)

--- a/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
@@ -79,34 +79,6 @@ interface ContentMapperInterface
     );
 
     /**
-     * saves the given data in the content storage.
-     *
-     * @param array       $data               The data to be saved
-     * @param string      $templateKey        Name of template
-     * @param string      $webspaceKey        Key of webspace
-     * @param string      $languageCode       Save data for given language
-     * @param int         $userId             The id of the user who saves
-     * @param bool        $partialUpdate      ignore missing property
-     * @param bool|null   $isShadow           indicates that this node is a shadow for the base language
-     * @param string|null $shadowBaseLanguage base language for shadow
-     *
-     * @throws \PHPCR\ItemExistsException if new title already exists
-     * @throws \InvalidArgumentException  if mandatory data is not valid or not passed
-     *
-     * @return StructureInterface
-     */
-    public function saveStartPage(
-        $data,
-        $templateKey,
-        $webspaceKey,
-        $languageCode,
-        $userId,
-        $partialUpdate = true,
-        $isShadow = null,
-        $shadowBaseLanguage = null
-    );
-
-    /**
      * returns a list of data from children of given node.
      *
      * @param string $uuid             The uuid of the parent node

--- a/tests/Sulu/Component/Content/Mapper/ContentMapperTest.php
+++ b/tests/Sulu/Component/Content/Mapper/ContentMapperTest.php
@@ -59,6 +59,11 @@ class ContentMapperTest extends SuluTestCase
     private $session;
 
     /**
+     * @var SessionManager
+     */
+    private $sessionManager;
+
+    /**
      * @var ExtensionManager
      */
     private $extensionManager;
@@ -80,6 +85,7 @@ class ContentMapperTest extends SuluTestCase
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
+        $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->extensionManager = $this->getContainer()->get('sulu_content.extension.manager');
         $this->contentTypeManager = $this->getContainer()->get('sulu.content.type_manager');
 
@@ -1005,7 +1011,13 @@ class ContentMapperTest extends SuluTestCase
             ],
         ];
 
-        $this->mapper->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'de', 1);
+        $this->saveStartPage(
+            ['title' => 'Start Page'],
+            'overview',
+            'sulu_io',
+            'de',
+            1
+        );
 
         // save root content
         $result['root'] = $this->mapper->save($data[0], 'overview', 'sulu_io', 'de', 1);
@@ -1148,58 +1160,6 @@ class ContentMapperTest extends SuluTestCase
         $this->assertEquals(1, count($children));
         $this->assertEquals('Testnews-2-1', $children[0]->title);
         $this->assertEquals('/news/testnews-2/testnews-2-1', $children[0]->getPath());
-    }
-
-    public function testStartPage()
-    {
-        $data = [
-            'title' => 'startpage',
-            'tags' => [
-                'tag1',
-                'tag2',
-            ],
-            'url' => '/',
-            'article' => 'article',
-        ];
-
-        $this->mapper->saveStartPage($data, 'overview', 'sulu_io', 'en', 1, false);
-
-        $startPage = $this->mapper->loadStartPage('sulu_io', 'en');
-        $this->assertEquals('startpage', $startPage->title);
-        $this->assertEquals('/', $startPage->url);
-
-        $data['title'] = 'new-startpage';
-
-        $this->mapper->saveStartPage($data, 'overview', 'sulu_io', 'en', 1, false);
-
-        $startPage = $this->mapper->loadStartPage('sulu_io', 'en');
-        $this->assertEquals('new-startpage', $startPage->title);
-        $this->assertEquals('/', $startPage->url);
-
-        $startPage = $this->mapper->loadByResourceLocator('/', 'sulu_io', 'en');
-        $this->assertEquals('new-startpage', $startPage->title);
-        $this->assertEquals('/', $startPage->url);
-    }
-
-    public function testShadowStartPage()
-    {
-        $data = [
-            'title' => 'startpage',
-            'tags' => [
-                'tag1',
-                'tag2',
-            ],
-            'url' => '/',
-            'article' => 'article',
-        ];
-
-        $this->mapper->saveStartPage($data, 'overview', 'sulu_io', 'en', 1, false);
-
-        $this->mapper->saveStartPage(['title' => 'Startseite'], 'overview', 'sulu_io', 'de', 1, false, true, 'en');
-
-        $startPage = $this->mapper->loadStartPage('sulu_io', 'de');
-        $this->assertEquals('startpage', $startPage->title);
-        $this->assertEquals('/', $startPage->url);
     }
 
     public function testDelete()
@@ -1484,7 +1444,13 @@ class ContentMapperTest extends SuluTestCase
             ],
         ];
 
-        $this->mapper->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'de', 1);
+        $this->saveStartPage(
+            ['title' => 'Start Page'],
+            'overview',
+            'sulu_io',
+            'de',
+            1
+        );
 
         // save root content
         $result['news-en'] = $this->mapper->save($data[0], 'overview', 'sulu_io', 'en', 1);
@@ -2100,8 +2066,8 @@ class ContentMapperTest extends SuluTestCase
 
     private function prepareCopyLanguageTree()
     {
-        $this->mapper->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'de', 1);
-        $this->mapper->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'en', 1);
+        $this->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'de', 1);
+        $this->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'en', 1);
 
         $data = [
             [
@@ -2590,8 +2556,8 @@ class ContentMapperTest extends SuluTestCase
 
     private function prepareSinglePageTestData()
     {
-        $this->mapper->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'de', 1);
-        $this->mapper->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'en', 1);
+        $this->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'de', 1);
+        $this->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'en', 1);
 
         $data = [
             'title' => 'Page-1',
@@ -2655,7 +2621,7 @@ class ContentMapperTest extends SuluTestCase
             ],
         ];
 
-        $this->mapper->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'de', 1);
+        $this->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'de', 1);
 
         // save content
         $data[0] = $this->mapper->save($data[0], 'overview', 'sulu_io', 'de', 1);
@@ -2701,7 +2667,7 @@ class ContentMapperTest extends SuluTestCase
             ],
         ];
 
-        $this->mapper->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'en', 1);
+        $this->saveStartPage(['title' => 'Start Page'], 'overview', 'sulu_io', 'en', 1);
 
         $data[0] = $this->mapper->save($data[0], 'overview', 'sulu_io', 'en', 1);
         $data[1] = $this->mapper->save($data[1], 'overview', 'sulu_io', 'en', 1, true, null, $data[0]->getUuid());
@@ -3391,6 +3357,32 @@ class ContentMapperTest extends SuluTestCase
         $userToken->setUser($user->reveal());
 
         return $userToken;
+    }
+
+    /**
+     * @return mixed
+     */
+    private function getHomeUuid()
+    {
+        return $this->sessionManager->getContentNode('sulu_io')->getIdentifier();
+    }
+
+    private function saveStartPage($data, $templateKey, $webspaceKey, $locale, $userId)
+    {
+        $this->mapper->save(
+            $data,
+            $templateKey,
+            $webspaceKey,
+            $locale,
+            $userId,
+            true,
+            $this->getHomeUuid(),
+            null,
+            WorkflowStage::PUBLISHED,
+            null,
+            null,
+            'home'
+        );
     }
 }
 


### PR DESCRIPTION
Removes the special handling for an ID called `index`, and uses the real ID of the startpage also in the frontend instead.

Required in order for the permissions in #1477 to be working with the start page.

__tasks:__

- [x] test coverage
- [x] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | `saveStartPage` and corresponding methods have been removed
| Documentation PR | none