### PR TITLE
fixed redirect on external link page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #1532 [WebsiteBundle]  Fixed redirect to external pages
     * HOTFIX      #1511 [ContentBundle]  Fixed single-internal-link overlay URL
     * HOTFIX      #1521 [MediaBundle]    Fixed media-selection events for preview update
 

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -122,7 +122,7 @@ class ContentRouteProvider implements RouteProviderInterface
                 ) {
                     $collection->add(
                         $content->getKey() . '_' . uniqid(),
-                        $this->getRedirectRoute($request, 'http://' . $content->getPropertyValueByTagName('sulu.rlp'))
+                        $this->getRedirectRoute($request, $content->getResourceLocator())
                     );
                 } elseif (
                     $content->getNodeState() === StructureInterface::STATE_TEST ||

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -42,7 +42,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $localization = new Localization();
         $localization->setLanguage('de');
 
-        $structure = $this->getStructureMock($uuid, 1);
+        $structure = $this->getStructureMock($uuid, null, 1);
         $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix, $localization);
         $activeTheme = $this->getActiveThemeMock();
 
@@ -295,7 +295,12 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $webspace->setTheme($theme);
         $portal->setWebspace($webspace);
 
-        $structure = $this->getStructureMock($uuid, Structure::STATE_PUBLISHED, Structure::NODE_TYPE_INTERNAL_LINK);
+        $structure = $this->getStructureMock(
+            $uuid,
+            '/other-test',
+            Structure::STATE_PUBLISHED,
+            Structure::NODE_TYPE_INTERNAL_LINK
+        );
 
         $locale = new Localization();
         $locale->setLanguage('en');
@@ -337,7 +342,12 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $webspace->setTheme($theme);
         $portal->setWebspace($webspace);
 
-        $structure = $this->getStructureMock($uuid, Structure::STATE_PUBLISHED, Structure::NODE_TYPE_EXTERNAL_LINK);
+        $structure = $this->getStructureMock(
+            $uuid,
+            'http://www.example.org',
+            Structure::STATE_PUBLISHED,
+            Structure::NODE_TYPE_EXTERNAL_LINK
+        );
 
         $locale = new Localization();
         $locale->setLanguage('en');
@@ -457,8 +467,12 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
     /**
      * @return PageBridge
      */
-    protected function getStructureMock($uuid, $state = Structure::STATE_PUBLISHED, $type = Structure::NODE_TYPE_CONTENT)
-    {
+    protected function getStructureMock(
+        $uuid,
+        $resourceLocator = null,
+        $state = Structure::STATE_PUBLISHED,
+        $type = Structure::NODE_TYPE_CONTENT
+    ) {
         $structure = $this->prophesize(PageBridge::class);
 
         $structure->getUuid()->willReturn($uuid);
@@ -467,8 +481,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $structure->getHasTranslation()->willReturn(true);
         $structure->getController()->willReturn('');
         $structure->getKey()->willReturn('key');
-        $structure->getResourceLocator()->willReturn('/other-test');
-        $structure->getPropertyValueByTagName(Argument::any())->willReturn('www.example.org');
+        $structure->getResourceLocator()->willReturn($resourceLocator);
 
         return $structure->reveal();
     }


### PR DESCRIPTION
Currently the external link does redirect to the resource locator of the page, instead of its defined external link.

__tasks:__

- [x] test coverage
- [x] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none