### PR TITLE
fixed canonical tag for shadow pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #1539 [WebsiteBundle]  Fixed canonical tag for shadow pages
     * HOTFIX      #1532 [WebsiteBundle]  Fixed redirect to external pages
     * HOTFIX      #1511 [ContentBundle]  Fixed single-internal-link overlay URL
     * HOTFIX      #1521 [MediaBundle]    Fixed media-selection events for preview update

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade
 
+## 1.0.8
+
+The `sulu_meta_seo` twig method does not render the canonical tag for shadow pages. Therefore this method is deprecated
+and will be removed with Sulu 1.2. Use the new `sulu_seo` method instead. This method will also render the title, so
+there is no need for the title block as it has been in the Sulu standard edition anymore.
+
 ## 1.0.6
 
 ### Configuration

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Structure/SeoStructureExtensionTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Structure/SeoStructureExtensionTest.php
@@ -12,11 +12,8 @@
 namespace Sulu\Bundle\ContentBundle\Tests\Unit\Structure;
 
 use PHPCR\NodeInterface;
+use Prophecy\Argument;
 use Sulu\Bundle\ContentBundle\Content\Structure\SeoStructureExtension;
-
-abstract class TestProperty implements \Iterator, NodeInterface
-{
-}
 
 /**
  * @group unit
@@ -26,7 +23,7 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
     /**
      * @var NodeInterface
      */
-    private $nodeMock;
+    private $node;
 
     /**
      * @var SeoStructureExtension
@@ -35,7 +32,7 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->nodeMock = $this->getMock('Sulu\Bundle\ContentBundle\Tests\Unit\Structure\TestProperty');
+        $this->node = $this->prophesize(NodeInterface::class);
         $this->extension = new SeoStructureExtension();
     }
 
@@ -47,16 +44,11 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
     public function testSave()
     {
         $content = [];
-        $this->nodeMock
-            ->expects($this->exactly(7))
-            ->method('setProperty')
-            ->will(
-                $this->returnCallback(
-                    function ($property, $value) use (&$content) {
-                        $content[$property] = $value;
-                    }
-                )
-            );
+        $this->node->setProperty(Argument::any(), Argument::any())->will(
+            function ($arguments) use (&$content) {
+                $content[$arguments[0]] = $arguments[1];
+            }
+        );
 
         $data = [
             'title' => 'Title',
@@ -68,7 +60,7 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
             'hideInSitemap' => true,
         ];
         $this->extension->setLanguageCode('de', 'i18n', null);
-        $this->extension->save($this->nodeMock, $data, 'default', 'de');
+        $this->extension->save($this->node->reveal(), $data, 'default', 'de');
 
         $this->assertEquals(
             [
@@ -87,20 +79,15 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
     public function testSaveWithoutData()
     {
         $content = [];
-        $this->nodeMock
-            ->expects($this->exactly(7))
-            ->method('setProperty')
-            ->will(
-                $this->returnCallback(
-                    function ($property, $value) use (&$content) {
-                        $content[$property] = $value;
-                    }
-                )
-            );
+        $this->node->setProperty(Argument::any(), Argument::any())->will(
+            function ($arguments) use (&$content) {
+                $content[$arguments[0]] = $arguments[1];
+            }
+        );
 
         $data = [];
         $this->extension->setLanguageCode('de', 'i18n', null);
-        $this->extension->save($this->nodeMock, $data, 'default', 'de');
+        $this->extension->save($this->node->reveal(), $data, 'default', 'de');
 
         $this->assertEquals(
             [
@@ -137,23 +124,19 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
             'i18n:de-seo-noFollow' => $data['noFollow'],
             'i18n:de-seo-hideInSitemap' => $data['hideInSitemap'],
         ];
-        $this->nodeMock
-            ->expects($this->exactly(7))
-            ->method('getPropertyValueWithDefault')
-            ->will(
-                $this->returnCallback(
-                    function ($property, $default) use (&$content) {
-                        if (isset($content[$property])) {
-                            return $content[$property];
-                        } else {
-                            return $default;
-                        }
-                    }
-                )
-            );
+
+        $this->node->getPropertyValueWithDefault(Argument::any(), Argument::any())->will(
+            function ($arguments) use (&$content) {
+                if (isset($content[$arguments[0]])) {
+                    return $content[$arguments[0]];
+                } else {
+                    return $arguments[1];
+                }
+            }
+        );
 
         $this->extension->setLanguageCode('de', 'i18n', null);
-        $this->extension->load($this->nodeMock, 'default', 'de');
+        $this->extension->load($this->node->reveal(), 'default', 'de');
 
         $this->assertEquals(
             [
@@ -172,23 +155,19 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
     public function testLoadWithoutData()
     {
         $content = [];
-        $this->nodeMock
-            ->expects($this->exactly(7))
-            ->method('getPropertyValueWithDefault')
-            ->will(
-                $this->returnCallback(
-                    function ($property, $default) use (&$content) {
-                        if (isset($content[$property])) {
-                            return $content[$property];
-                        } else {
-                            return $default;
-                        }
-                    }
-                )
-            );
+
+        $this->node->getPropertyValueWithDefault(Argument::any(), Argument::any())->will(
+            function ($arguments) use (&$content) {
+                if (isset($content[$arguments[0]])) {
+                    return $content[$arguments[0]];
+                } else {
+                    return $arguments[1];
+                }
+            }
+        );
 
         $this->extension->setLanguageCode('de', 'i18n', null);
-        $result = $this->extension->load($this->nodeMock, 'default', 'de');
+        $result = $this->extension->load($this->node->reveal(), 'default', 'de');
 
         $this->assertEquals(
             [

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -64,6 +64,7 @@ class StructureResolver implements StructureResolverInterface
             $data['extension'] = $structure->getExt()->toArray();
             $data['urls'] = $structure->getUrls();
             $data['published'] = $structure->getPublished();
+            $data['shadowBaseLocale'] = $structure->getShadowBaseLanguage();
 
             foreach ($data['extension'] as $name => $value) {
                 $extension = $this->structureManager->getExtension($structure->getKey(), $name);

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -16,6 +16,7 @@
         <parameter key="sulu_website.twig.content.class">Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension</parameter>
         <parameter key="sulu_website.twig.content.memoized.class">Sulu\Bundle\WebsiteBundle\Twig\Content\MemoizedContentTwigExtension</parameter>
         <parameter key="sulu_website.twig.Meta.class">Sulu\Bundle\WebsiteBundle\Twig\Meta\MetaTwigExtension</parameter>
+        <parameter key="sulu_website.twig.seo.class">Sulu\Bundle\WebsiteBundle\Twig\Seo\SeoTwigExtension</parameter>
         <parameter key="sulu_website.twig.util.class">Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension</parameter>
         <parameter key="sulu_website.routing.portal_loader.class">Sulu\Bundle\WebsiteBundle\Routing\PortalLoader</parameter>
         <parameter key="sulu_website.exception.controller.class">Sulu\Bundle\WebsiteBundle\Controller\ExceptionController</parameter>
@@ -119,6 +120,13 @@
 
         <!-- twig extension: meta -->
         <service id="sulu_website.twig.meta" class="%sulu_website.twig.meta.class%">
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="sulu_website.twig.content_path"/>
+
+            <tag name="twig.extension"/>
+        </service>
+
+        <service id="sulu_website.twig.seo" class="%sulu_website.twig.seo.class%">
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.twig.content_path"/>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
@@ -80,6 +80,7 @@ class StructureResolverTest extends \PHPUnit_Framework_TestCase
         $structure->getPublished()->willReturn('date');
         $structure->getPath()->willReturn('test-path');
         $structure->getUrls()->willReturn(['en' => '/description', 'de' => '/beschreibung', 'es' => null]);
+        $structure->getShadowBaseLanguage()->willReturn('en');
 
         $expected = [
             'extension' => [
@@ -100,6 +101,7 @@ class StructureResolverTest extends \PHPUnit_Framework_TestCase
             'template' => 'test',
             'urls' => ['en' => '/description', 'de' => '/beschreibung', 'es' => null],
             'path' => 'test-path',
+            'shadowBaseLocale' => 'en',
         ];
 
         $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal()));

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
@@ -1,0 +1,242 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Twig\Seo;
+
+use Prophecy\Argument;
+use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathInterface;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\Webspace;
+
+class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SeoTwigExtension
+     */
+    private $seoTwigExtension;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var ContentPathInterface
+     */
+    private $contentPath;
+
+    public function setUp()
+    {
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->contentPath = $this->prophesize(ContentPathInterface::class);
+        $this->seoTwigExtension = new SeoTwigExtension($this->requestAnalyzer->reveal(), $this->contentPath->reveal());
+    }
+
+    public function testGetFunctions()
+    {
+        $result = $this->seoTwigExtension->getFunctions();
+
+        $this->assertEquals(
+            new \Twig_SimpleFunction('sulu_seo', [$this->seoTwigExtension, 'renderSeoTags']),
+            $result[0]
+        );
+    }
+
+    /**
+     * @dataProvider provideSeoData
+     *
+     * @param $seoExtension
+     * @param $content
+     * @param $urls
+     * @param $defaultLocale
+     * @param $shadowBaseLocale
+     * @param $expectedResults
+     * @param array $unexpectedResults
+     */
+    public function testRenderSeoTags(
+        $seoExtension,
+        $content,
+        $urls,
+        $defaultLocale,
+        $shadowBaseLocale,
+        $expectedResults,
+        $unexpectedResults = []
+    ) {
+        /** @var Localization $localization */
+        $localization = $this->prophesize(Localization::class);
+        $localization->getLocalization()->willReturn($defaultLocale);
+
+        /** @var Portal $portal */
+        $portal = $this->prophesize(Portal::class);
+        $portal->getDefaultLocalization()->willReturn($localization->reveal());
+
+        $this->requestAnalyzer->getPortal()->willReturn($portal->reveal());
+
+        $webspace = $this->prophesize(Webspace::class);
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->contentPath->getContentPath(Argument::cetera())->will(
+            function ($arguments) {
+                return '/' . str_replace('_', '-', $arguments[2]) . $arguments[0];
+            }
+        );
+
+        $result = $this->seoTwigExtension->renderSeoTags($seoExtension, $content, $urls, $shadowBaseLocale);
+
+        foreach ($expectedResults as $expectedResult) {
+            $this->assertContains($expectedResult, $result);
+        }
+
+        foreach ($unexpectedResults as $unexpectedResult) {
+            $this->assertNotContains($unexpectedResult, $result);
+        }
+    }
+
+    public function testRenderSeoTagsWithoutPortal()
+    {
+        $this->seoTwigExtension->renderSeoTags([], [], [], null);
+    }
+
+    public function provideSeoData()
+    {
+        return [
+            [
+                [
+                    'title' => 'SEO title',
+                    'description' => 'SEO description',
+                    'keywords' => 'SEO keywords',
+                    'canonicalUrl' => '/canonical-url',
+                    'noIndex' => true,
+                    'noFollow' => true,
+                    'hideInSitemap' => true,
+                ],
+                [
+                    'title' => 'Content title',
+                ],
+                [
+                    'en' => '/url-en',
+                    'de' => '/url-de',
+                ],
+                'en',
+                'en',
+                [
+                    '<title>SEO title</title>',
+                    '<meta name="description" content="SEO description"/>',
+                    '<meta name="keywords" content="SEO keywords"/>',
+                    '<meta name="robots" content="noIndex,noFollow"/>',
+                    '<link rel="alternate" href="/en/url-en" hreflang="x-default"/>',
+                    '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
+                    '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
+                    '<link rel="canonical" href="/canonical-url"/>',
+                ],
+            ],
+            [
+                [
+                    'title' => '',
+                    'description' => '',
+                    'keywords' => '',
+                    'canonicalUrl' => '',
+                    'noIndex' => false,
+                    'noFollow' => false,
+                    'hideInSitemap' => true,
+                ],
+                [
+                    'title' => 'Content title',
+                ],
+                [
+                    'en' => '/url-en',
+                    'de' => '/url-de',
+                ],
+                'de',
+                'en',
+                [
+                    '<title>Content title</title>',
+                    '<meta name="robots" content="index,follow"/>',
+                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
+                    '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
+                    '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
+                    '<link rel="canonical" href="/en/url-en"/>',
+                ],
+                [
+                    '<meta name="description" content=""/>',
+                    '<meta name="keywords" content=""/>',
+                ],
+            ],
+            [
+                [
+                    'title' => '',
+                    'description' => '',
+                    'keywords' => '',
+                    'canonicalUrl' => '',
+                    'noIndex' => false,
+                    'noFollow' => false,
+                    'hideInSitemap' => true,
+                ],
+                [
+                    'title' => 'Content title',
+                ],
+                [
+                    'en' => '/url-en',
+                    'de' => '/url-de',
+                ],
+                'de',
+                null,
+                [
+                    '<title>Content title</title>',
+                    '<meta name="robots" content="index,follow"/>',
+                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
+                    '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
+                    '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
+                ],
+                [
+                    '<meta name="description" content=""/>',
+                    '<meta name="keywords" content=""/>',
+                    '<link rel="canonical" href=""/>',
+                ],
+            ],
+            [
+                [
+                    'title' => '',
+                    'description' => '',
+                    'keywords' => '',
+                    'canonicalUrl' => '/canonical-url',
+                    'noIndex' => false,
+                    'noFollow' => false,
+                    'hideInSitemap' => true,
+                ],
+                [
+                    'title' => 'Content title',
+                ],
+                [
+                    'en' => '/url-en',
+                    'de' => '/url-de',
+                    'de_at' => '/url-de-at'
+                ],
+                'de',
+                null,
+                [
+                    '<title>Content title</title>',
+                    '<meta name="robots" content="index,follow"/>',
+                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
+                    '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
+                    '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
+                    '<link rel="alternate" href="/de-at/url-de-at" hreflang="de-at"/>',
+                    '<link rel="canonical" href="/canonical-url"/>',
+                ],
+                [
+                    '<meta name="description" content=""/>',
+                    '<meta name="keywords" content=""/>',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
@@ -16,6 +16,8 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 
 /**
  * Provides helper function to generate meta tags.
+ *
+ * @deprecated will be removed in 1.2
  */
 class MetaTwigExtension extends \Twig_Extension
 {

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -1,0 +1,233 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Twig\Seo;
+
+use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+
+/**
+ * This twig extension provides support for the SEO functionality provided by Sulu.
+ */
+class SeoTwigExtension extends \Twig_Extension
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var ContentPathInterface
+     */
+    private $contentPath;
+
+    public function __construct(RequestAnalyzerInterface $requestAnalyzer, ContentPathInterface $contentPath)
+    {
+        $this->requestAnalyzer = $requestAnalyzer;
+        // FIXME Should not use another twig extension here, that is not the intended use case of twig extensions
+        $this->contentPath = $contentPath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sulu_seo';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('sulu_seo', [$this, 'renderSeoTags']),
+        ];
+    }
+
+    /**
+     * Renders all the SEO tags supported by Sulu.
+     *
+     * @param array $seoExtension The values delivered by the SEO extension of Sulu
+     * @param array $content The content of the current page
+     * @param string[] $urls All the localized URLs for the current page
+     * @param string $shadowBaseLocale The displayed language, in case the current page is a shadow
+     *
+     * @return string The rendered HTML tags of the SEO extension
+     */
+    public function renderSeoTags(array $seoExtension, array $content, array $urls, $shadowBaseLocale)
+    {
+        $html = '';
+        // FIXME this is only necessary because we have to set a default parameter
+        $webspace = $this->requestAnalyzer->getWebspace();
+        $webspaceKey = null;
+        if ($webspace) {
+            $webspaceKey = $webspace->getKey();
+        }
+
+        $html .= $this->renderTitle($seoExtension, $content);
+        $html .= $this->renderMetaTags($seoExtension);
+        $html .= $this->renderAlternateLinks($urls, $webspaceKey);
+        $html .= $this->renderCanonicalTag($seoExtension, $urls, $shadowBaseLocale, $webspaceKey);
+
+        return $html;
+    }
+
+    /**
+     * Renders the correct title of the current page. The correct title is either the title provided by the SEO
+     * extension, or the title of the content, if the SEO extension does not provide one.
+     *
+     * @param array $seoExtension The values delivered by the SEO extension of Sulu
+     * @param array $content The content of the current page
+     *
+     * @return string The rendered title tag
+     */
+    private function renderTitle(array $seoExtension, array $content)
+    {
+        $titleHtml = '<title>%s</title>';
+
+        if (isset($seoExtension['title']) && $seoExtension['title'] !== '') {
+            return sprintf($titleHtml, $seoExtension['title']);
+        }
+
+        if (isset($content['title'])) {
+            return sprintf($titleHtml . PHP_EOL, $content['title']);
+        }
+
+        return '';
+    }
+
+    /**
+     * Renders the meta tags of the SEO extension. Contains the description, keywords and the robots settings.
+     *
+     * @param array $seoExtension The values delivered by the SEO extension of Sulu
+     *
+     * @return string The rendered meta tags
+     */
+    private function renderMetaTags(array $seoExtension)
+    {
+        $html = '';
+
+        if (isset($seoExtension['description']) && $seoExtension['description'] !== '') {
+            $html .= $this->renderMetaTag('description', $seoExtension['description']);
+        }
+
+        if (isset($seoExtension['keywords']) && $seoExtension['keywords'] !== '') {
+            $html .= $this->renderMetaTag('keywords', $seoExtension['keywords']);
+        }
+
+        $robots = [];
+        if (isset($seoExtension['noIndex']) && $seoExtension['noIndex'] === true) {
+            $robots[] = 'noIndex';
+        } else {
+            $robots[] = 'index';
+        }
+
+        if (isset($seoExtension['noFollow']) && $seoExtension['noFollow'] === true) {
+            $robots[] = 'noFollow';
+        } else {
+            $robots[] = 'follow';
+        }
+
+        $html .= $this->renderMetaTag('robots', implode(',', $robots));
+
+        return $html;
+    }
+
+    /**
+     * Renders a simple meta tag.
+     *
+     * @param string $name The name of the meta tag
+     * @param string $content The content of the meta tag
+     * @return string The HTMl meta tag filled with the given values
+     */
+    private function renderMetaTag($name, $content)
+    {
+        return sprintf('<meta name="%s" content="%s"/>' . PHP_EOL, $name, $content);
+    }
+
+    /**
+     * Renders the alternate links for this page, this means all the localizations in which this page is available. In
+     * addition the default localization is also rendered.
+     *
+     * @param string[] $urls All the localized URLs for the current page
+     * @param string $webspaceKey The key of the current webspace
+     *
+     * @return string The rendered HTML tags
+     */
+    private function renderAlternateLinks(array $urls, $webspaceKey)
+    {
+        $html = '';
+
+        $portal = $this->requestAnalyzer->getPortal();
+        $defaultLocale = null;
+        if ($portal) {
+            $defaultLocale = $portal->getDefaultLocalization()->getLocalization();
+
+            $html .= $this->renderAlternateLink($urls[$defaultLocale], $webspaceKey, $defaultLocale, true);
+        }
+
+        foreach ($urls as $locale => $url) {
+            $html .= $this->renderAlternateLink($url, $webspaceKey, $locale);
+        }
+
+        return $html;
+    }
+
+    /**
+     * Renders a single alternate link.
+     *
+     * @param string $url The url for the given locale of the current page
+     * @param string $webspaceKey The key of the current webspace
+     * @param string $locale The locale for which the tag should be rendered
+     * @param bool $default If true the tag will be rendered as default locale
+     *
+     * @return string The rendered alternate link tag
+     */
+    private function renderAlternateLink($url, $webspaceKey, $locale, $default = false)
+    {
+        return sprintf(
+            '<link rel="alternate" href="%s" hreflang="%s"/>' . PHP_EOL,
+            $this->contentPath->getContentPath($url, $webspaceKey, $locale),
+            $default ? 'x-default' : str_replace('_', '-', $locale)
+        );
+    }
+
+    /**
+     * Renders the canonical tag for the current page. Uses the value provided by the SEO extension. If the SEO
+     * extension does not provide a value, it checks if the current page is a shadow, and writes the correct canonical
+     * tag automatically.
+     *
+     * @param array $seoExtension The values delivered by the SEO extension of Sulu
+     * @param string[] $urls All the localized URLs for the current page
+     * @param string $shadowBaseLocale The displayed language, in case the current page is a shadow
+     * @param string $webspaceKey The key of the current webspace
+     *
+     * @return string The rendered canonical link tag
+     */
+    private function renderCanonicalTag(array $seoExtension, array $urls, $shadowBaseLocale, $webspaceKey)
+    {
+        $canonicalTagHtml = '<link rel="canonical" href="%s"/>' . PHP_EOL;
+
+        if (isset($seoExtension['canonicalUrl']) && $seoExtension['canonicalUrl'] !== '') {
+            return sprintf($canonicalTagHtml, $seoExtension['canonicalUrl']);
+        }
+
+        if ($shadowBaseLocale && isset($urls[$shadowBaseLocale])) {
+            return sprintf(
+                $canonicalTagHtml,
+                $this->contentPath->getContentPath($urls[$shadowBaseLocale], $webspaceKey, $shadowBaseLocale)
+            );
+        }
+
+        return '';
+    }
+}


### PR DESCRIPTION
Fixes the canonical tag issue for shadow pages in a new twig extension. Also fixes #1533.

__tasks:__

- [x] test coverage
- [x] gather feedback for my changes
- [ ] submit changes to the documentation

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | fixes #1533 
| BC breaks        | `sulu_meta_seo` twig method is now deprecated, use `sulu_seo` instead
| Documentation PR | https://github.com/sulu-io/sulu-docs/pull/70