### PR TITLE
fix website request analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1586 [Webspace]        Fixed request format
     * BUGFIX      #1583 [ResourceBundle]  Fixed filter button in list-toolbar
     * FEATURE     #1558 [AdminBundle]     Redesign of overlays
     * FEATURE     #1557 [MediaBundle]     Redesign of data-navigation

--- a/src/Sulu/Component/Webspace/Analyzer/WebsiteRequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/WebsiteRequestAnalyzer.php
@@ -398,7 +398,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
 
         $path = rtrim(implode('/', $pathParts), '/') . '/' . $fileInfo[0];
         if (count($fileInfo) > 1) {
-            $formatResult = $fileInfo[1];
+            $formatResult = end($fileInfo);
         } else {
             $formatResult = null;
         }


### PR DESCRIPTION
The ```WebsiteRequestAnalyzer``` sets the request format by exploding the requested file name by dots and extract the format from the resulting array. When a filename has multiple dots in it, the second item will be set as the request format (and not the last one as it should be).
This is behaviour is fixed by this PR.

Example:
A request for ```bootstrap.min.css``` results the file format ```min```. Expected would be ```css```

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none