### PR TITLE
[hotfix] fix website request analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #1594 [Website]       Fixed website request analyzer
+
 * 1.0.9 (2015-09-14)
     * HOTFIX      #1572 [ContentBundle]         Fixed select overlay for internal link node type
     * HOTFIX      #1567 [Document]              Fixed localized property for url property

--- a/src/Sulu/Component/Webspace/Analyzer/WebsiteRequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/WebsiteRequestAnalyzer.php
@@ -398,7 +398,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
 
         $path = rtrim(implode('/', $pathParts), '/') . '/' . $fileInfo[0];
         if (sizeof($fileInfo) > 1) {
-            $formatResult = $fileInfo[1];
+            $formatResult = end($fileInfo);
         } else {
             $formatResult = null;
         }

--- a/tests/Sulu/Component/Webspace/Analyzer/RequestAnalyzerTest.php
+++ b/tests/Sulu/Component/Webspace/Analyzer/RequestAnalyzerTest.php
@@ -152,6 +152,21 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
                     'format' => null,
                 ],
             ],
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'path_info' => '/test/path/to/test.min.css',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to/test.min.css',
+                    'portal_url' => 'sulu.lo/test',
+                    'format' => 'css',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Moved PR #1586 to master branch as hotfix

The ```WebsiteRequestAnalyzer``` sets the request format by exploding the requested file name by dots and extract the format from the resulting array. When a filename has multiple dots in it, the second item will be set as the request format (and not the last one as it should be).
This is behaviour is fixed by this PR.

Example:
A request for ```bootstrap.min.css``` results the file format ```min```. Expected would be ```css```

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none