### PR TITLE
[hotfix] fixed sulu bundle generator path generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #1596 [GeneratorBundle] fixed sulu bundle generator path generation
+
 * 1.0.10 (2015-09-17)
-    * HOTFIX      #1594 [Website] Fixed website request analyzer
+    * HOTFIX      #1594 [Website]Fixed website request analyzer
     * HOTFIX      #1594 [Website] Fixed trailing slash for homepage
 
 * 1.0.9 (2015-09-14)

--- a/src/Sulu/Bundle/GeneratorBundle/Command/GenerateBundleCommand.php
+++ b/src/Sulu/Bundle/GeneratorBundle/Command/GenerateBundleCommand.php
@@ -193,7 +193,7 @@ EOT
             $d = str_replace('\\', '/', $d);
             $d = str_replace('/bundle/', '/', $d);
             $d = str_replace('bundle', '', $d);
-            $dir = dirname(dirname($this->getContainer()->getParameter('kernel.root_dir'))) . '/vendor/' . $d . '-bundle/';
+            $dir = dirname($this->getContainer()->getParameter('kernel.root_dir')) . '/vendor/' . $d . '-bundle/';
 
             $output->writeln([
                 '',


### PR DESCRIPTION
This PR fixes the incorrect path generation of the ```sulu:generate:bundle``` command when no target path is provided manually.

According to the ```symfony2``` directory structure the ```vendor``` directory is located one level above ```kernel.root_dir```. At the previous state the bundle tries to place the bundle inside a ```vendor``` directory which is two levels above ```kernel.root_dir```.

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none