### PR TITLE
added further null reference checks to MediaManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * ENHANCEMENT #1607 [ContactBundle]   Now passing savedData when calling save and create new account
+    * BUGFIX      #1609 [MediaBundle]     Added further null reference checks to MediaManager
     * BUGFIX      #1583 [ResourceBundle]  Fixed filter button in list-toolbar
     * ENHANCEMENT #1581 [CategoryBundle]  Added locale handling in list and list api
     * ENHANCEMENT #1581 [SnippetBundle]   Added locale chooser in list

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaContentNavigationProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaContentNavigationProvider.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\MediaBundle\Admin;
 
 use Sulu\Bundle\AdminBundle\Navigation\ContentNavigationItem;
 use Sulu\Bundle\AdminBundle\Navigation\ContentNavigationProviderInterface;
-use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
 class MediaContentNavigationProvider implements ContentNavigationProviderInterface

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -921,6 +921,14 @@ class MediaManager implements MediaManagerInterface
 
     protected function getCurrentUser()
     {
-        return $this->tokenStorage ? $this->tokenStorage->getToken()->getUser() : null;
+        if (!$this->tokenStorage) {
+            return;
+        }
+
+        if (!$this->tokenStorage->getToken()) {
+            return;
+        }
+
+        return $this->tokenStorage->getToken()->getUser();
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -142,6 +142,15 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGetWithoutToken()
+    {
+        $this->tokenStorage->getToken()->willReturn(null);
+        $this->mediaRepository->findMedia(Argument::cetera())->willReturn([])->shouldBeCalled();
+        $this->mediaRepository->count(Argument::cetera())->shouldBeCalled();
+
+        $this->mediaManager->get(1);
+    }
+
     public function testDeleteWithSecurity()
     {
         $collection = $this->prophesize(Collection::class);


### PR DESCRIPTION
This missing check caused the search reindex command to fail.

__tasks:__

- [x] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none