### PR TITLE
readded the reorder event to the OrderSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1614 [ContentBundle]   Readded the reorder event to the OrderSubscriber
     * ENHANCEMENT #1607 [ContactBundle]   Now passing savedData when calling save and create new account
     * BUGFIX      #1609 [MediaBundle]     Added further null reference checks to MediaManager
     * BUGFIX      #1583 [ResourceBundle]  Fixed filter button in list-toolbar

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -139,14 +139,6 @@ class NodeControllerTest extends SuluTestCase
                     'language' => 'en',
                 ],
             ],
-        //    array(
-        //        array(
-        //            'template' => 'hotel',
-        //            'webspace' => 'sulu_io',
-        //            'language' => 'en',
-        //            'type' => 'snippet',
-        //        ),
-        //    ),
         ];
     }
 
@@ -1233,6 +1225,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals('test2', $response['title']);
         $this->assertEquals('/test2', $response['path']);
         $this->assertEquals('/test2', $response['url']);
+        $this->assertEquals(30, $response['order']);
 
         $client->request(
             'POST',
@@ -1249,6 +1242,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals('test4', $response['title']);
         $this->assertEquals('/test4', $response['path']);
         $this->assertEquals('/test4', $response['url']);
+        $this->assertEquals(10, $response['order']);
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
@@ -1258,9 +1252,13 @@ class NodeControllerTest extends SuluTestCase
 
         $this->assertEquals(4, count($items));
         $this->assertEquals('test4', $items[0]['title']);
+        $this->assertEquals(10, $items[0]['order']);
         $this->assertEquals('test1', $items[1]['title']);
+        $this->assertEquals(20, $items[1]['order']);
         $this->assertEquals('test3', $items[2]['title']);
+        $this->assertEquals(30, $items[2]['order']);
         $this->assertEquals('test2', $items[3]['title']);
+        $this->assertEquals(40, $items[3]['order']);
     }
 
     public function testOrderNonExistingSource()

--- a/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
@@ -43,6 +43,7 @@ class OrderSubscriber implements EventSubscriberInterface
         return [
             Events::PERSIST => 'handlePersist',
             Events::METADATA_LOAD => 'handleMetadataLoad',
+            Events::REORDER => 'handleReorder',
         ];
     }
 
@@ -73,7 +74,6 @@ class OrderSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // TODO: This does not seem quite right..
         if ($document->getSuluOrder()) {
             return;
         }

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -673,7 +673,11 @@ class ContentMapper implements ContentMapperInterface
             $this->documentManager->reorder($document, $targetSibling->getPath());
         }
 
-        $this->documentManager->persist($document, $locale);
+        // this should not be necessary (see https://github.com/sulu-io/sulu-document-manager/issues/39)
+        foreach ($siblingDocuments as $siblingDocument) {
+            $this->documentManager->persist($siblingDocument, $locale);
+        }
+
         $this->documentManager->flush();
 
         return $this->documentToStructure($document);


### PR DESCRIPTION
Without this the ordering of pages is not working in the navigation of the website.

Created issue https://github.com/sulu-io/sulu-document-manager/issues/39
__tasks:__

- [ ] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none