### PR TITLE
removed allowed failures to improve test speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ php:
 
 env:
   - SULU_ORM=mysql SULU_PHPCR=jackrabbit
-  - SULU_ORM=mysql SULU_PHPCR=doctrine_dbal
-  - SULU_ORM=postgres SULU_PHPCR=jackrabbit
+#  - SULU_ORM=mysql SULU_PHPCR=doctrine_dbal
+#  - SULU_ORM=postgres SULU_PHPCR=jackrabbit
 
 before_script:
   - composer self-update
@@ -19,11 +19,6 @@ before_script:
 script: 
   - time ./bin/runtests.sh -i -a
   - phpunit
-
-matrix:
-  allow_failures:
-    - env: "SULU_ORM=mysql SULU_PHPCR=doctrine_dbal"
-    - env: "SULU_ORM=postgres SULU_PHPCR=jackrabbit"
 
 notifications:
   slack:


### PR DESCRIPTION
I decided to remove the allowed failure for jackalope doctrine dbal, because they are slowing down our tests, although all of us know they are currently failing. We can add them later again, once we fixed the jackalope doctrine dbal issues.

__tasks:__

- [ ] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none