### PR TITLE
Change email to protected to allow attribute overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
-    * HOTFIX      #1624 [ContentBundle] Fixed nullable internal link and added server/clientside validation
+    * HOTFIX      #1634 [SecurityBundle] Allow attribute overrides for user email field
+    * HOTFIX      #1624 [ContentBundle]  Fixed nullable internal link and added server/clientside validation
     
 * 1.0.11 (2015-09-23)
     * HOTFIX      #1596 [GeneratorBundle] Fixed sulu bundle generator path generation

--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
@@ -36,7 +36,7 @@ abstract class BaseUser extends ApiEntity implements UserInterface, Serializable
      * @var string
      * @Expose
      */
-    private $email;
+    protected $email;
 
     /**
      * @var string


### PR DESCRIPTION
currently its not possible to use attribute overrides in doctrine on the email. in my case I have on my website a protected area with login where the email address should not be unique.

e.g.
``` xml
        <attribute-overrides>
            <attribute-override name="email">
                <field unique="false" nullable="true" />
            </attribute-override>
        </attribute-overrides>
```

__Tasks:__

- [ ] test coverage
- [ ] gather feedback for my changes
- [ ] added changelog line


__Informations:__

| Q             | A
| ------------- | ---
| Fixed tickets | none
| BC Breaks     | none
| Doc           | none