### PR TITLE
added separate status code for occupied resource locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1660 [ContentBundle]   Added separate error message for occupied resource locator
     * BUGFIX      #1655 [ContentBundle]   Fixed ghost pages and phpcr access control provider
     * BUGFIX      #1649 [ContentBundle]   Fixed floating of block type select
     * BUGFIX      #1646 [ContactBundle]   Fixed upload of contact-avatar when a position is applied to the contact

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.de.xlf
@@ -358,18 +358,6 @@
                 <source>labels.warning</source>
                 <target>Warnung</target>
             </trans-unit>
-            <trans-unit id="2647c238cae0fa45d7fbad336e43750f" resname="labels.success.content-deleted-desc">
-                <source>labels.success.content-deleted-desc</source>
-                <target>Seite erfolgreich gelöscht.</target>
-            </trans-unit>
-            <trans-unit id="487f946d51783a9899fa59d31dcfc3e8" resname="labels.success.content-save-desc">
-                <source>labels.success.content-save-desc</source>
-                <target>Node erfolgreich gespeichert.</target>
-            </trans-unit>
-            <trans-unit id="75435af307a7ae8f965923968a0e0f94" resname="labels.error.content-save-desc">
-                <source>labels.error.content-save-desc</source>
-                <target>Seite konnte nicht gespeichert werden.</target>
-            </trans-unit>
             <trans-unit id="58b06d6f4d02d93226d543aa6df546cc" resname="sulu.matcher.unmatched-column">
                 <source>sulu.matcher.unmatched-column</source>
                 <target>Nicht zugeordnete Spalte</target>

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.en.xlf
@@ -358,18 +358,6 @@
                 <source>labels.warning</source>
                 <target>Warning</target>
             </trans-unit>
-            <trans-unit id="2647c238cae0fa45d7fbad336e43750f" resname="labels.success.content-deleted-desc">
-                <source>labels.success.content-deleted-desc</source>
-                <target>Node successfully deleted.</target>
-            </trans-unit>
-            <trans-unit id="487f946d51783a9899fa59d31dcfc3e8" resname="labels.success.content-save-desc">
-                <source>labels.success.content-save-desc</source>
-                <target>Node sucessfully saved</target>
-            </trans-unit>
-            <trans-unit id="75435af307a7ae8f965923968a0e0f94" resname="labels.error.content-save-desc">
-                <source>labels.error.content-save-desc</source>
-                <target>Node could not be saved.</target>
-            </trans-unit>
             <trans-unit id="58b06d6f4d02d93226d543aa6df546cc" resname="sulu.matcher.unmatched-column">
                 <source>sulu.matcher.unmatched-column</source>
                 <target>Unmatched column</target>

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
@@ -240,8 +240,16 @@ define([
             }, this);
 
             // content save-error
-            this.sandbox.on('sulu.content.contents.save-error', function() {
-                this.sandbox.emit('sulu.labels.error.show', 'labels.error.content-save-desc', 'labels.error');
+            this.sandbox.on('sulu.content.contents.save-error', function(status) {
+                if (status === 409) {
+                    this.sandbox.emit(
+                        'sulu.labels.error.show',
+                        'labels.error.content-save-resource-locator',
+                        'labels.error'
+                    );
+                } else {
+                    this.sandbox.emit('sulu.labels.error.show', 'labels.error.content-save-desc', 'labels.error');
+                }
                 this.setHeaderBar(false);
             }, this);
 
@@ -514,7 +522,7 @@ define([
                 null, {
                     // on success save contents id
                     success: function(response) {
-                        var model = response.toJSON(), parent;
+                        var model = response.toJSON();
                         if (!!this.options.id) {
                             this.sandbox.emit('sulu.content.contents.saved', model.id, model);
                         } else {
@@ -523,10 +531,10 @@ define([
                         this.afterSaveAction(action, !this.options.id);
                         def.resolve();
                     }.bind(this),
-                    error: function() {
+                    error: function(model, response) {
                         this.sandbox.logger.log("error while saving profile");
                         this.sandbox.emit('sulu.header.toolbar.item.enable', 'save');
-                        this.sandbox.emit('sulu.content.contents.save-error');
+                        this.sandbox.emit('sulu.content.contents.save-error', response.status);
                     }.bind(this)
                 });
 
@@ -544,7 +552,7 @@ define([
             } else if (action === 'new') {
                 var parent, breadcrumb = this.content.get('breadcrumb');
                 parent = ((!!this.options.id && breadcrumb.length > 1) ?
-                    breadcrumb[breadcrumb.length - 1].uuid : null) || this.options.parent;
+                        breadcrumb[breadcrumb.length - 1].uuid : null) || this.options.parent;
                 this.sandbox.emit('sulu.router.navigate',
                     'content/contents/' + this.options.webspace + '/' +
                     this.options.language + '/add' + ((!!parent) ? ':' + parent : '') + '/content',

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
@@ -495,6 +495,22 @@
                 <source>search-overlay.placeholder.page</source>
                 <target>Seiten durchsuchen...</target>
             </trans-unit>
+            <trans-unit id="75435af307a7ae8f965923968a0e0f94" resname="labels.error.content-save-desc">
+                <source>labels.error.content-save-desc</source>
+                <target>Seite konnte nicht gespeichert werden.</target>
+            </trans-unit>
+            <trans-unit id="75435af3a7a7a38f968923968a0e0f94" resname="labels.error.content-save-resource-locator">
+                <source>labels.error.content-save-resource-locator</source>
+                <target>Die angegebene Adresse ist nicht gültig.</target>
+            </trans-unit>
+            <trans-unit id="2647c238cae0fa45d7fbad336e43750f" resname="labels.success.content-deleted-desc">
+                <source>labels.success.content-deleted-desc</source>
+                <target>Seite erfolgreich gelöscht.</target>
+            </trans-unit>
+            <trans-unit id="487f946d51783a9899fa59d31dcfc3e8" resname="labels.success.content-save-desc">
+                <source>labels.success.content-save-desc</source>
+                <target>Node erfolgreich gespeichert.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
@@ -487,6 +487,22 @@
                 <source>search-overlay.placeholder.page</source>
                 <target>Search pages...</target>
             </trans-unit>
+            <trans-unit id="75435af307a7ae8f965923968a0e0f94" resname="labels.error.content-save-desc">
+                <source>labels.error.content-save-desc</source>
+                <target>Node could not be saved.</target>
+            </trans-unit>
+            <trans-unit id="75435af3a7a7a38f968923968a0e0f94" resname="labels.error.content-save-resource-locator">
+                <source>labels.error.content-save-resource-locator</source>
+                <target>The given Resource Locator is not valid.</target>
+            </trans-unit>
+            <trans-unit id="2647c238cae0fa45d7fbad336e43750f" resname="labels.success.content-deleted-desc">
+                <source>labels.success.content-deleted-desc</source>
+                <target>Node successfully deleted.</target>
+            </trans-unit>
+            <trans-unit id="487f946d51783a9899fa59d31dcfc3e8" resname="labels.success.content-save-desc">
+                <source>labels.success.content-save-desc</source>
+                <target>Node sucessfully saved</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -191,6 +191,27 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals($uuid, $content->getParent()->getIdentifier());
     }
 
+    public function testPostWithExistingResourceLocator()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = [
+            'title' => 'news',
+            'tags' => [
+                'tag1',
+                'tag2',
+            ],
+            'url' => '/test',
+            'article' => 'Test',
+        ];
+
+        $client->request('POST', '/api/nodes?template=default&webspace=sulu_io&language=en', $data);
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', '/api/nodes?template=default&webspace=sulu_io&language=en', $data);
+        $this->assertequals(409, $client->getResponse()->getStatusCode());
+    }
+
     public function testGet()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
Let the rest api return status 409 instead of 500, if the resource locator is already existing. Merge with https://github.com/sulu-io/sulu-standard/pull/525

__tasks:__

- [ ] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | fixes #1112 
| BC breaks        | none
| Documentation PR | none