### PR TITLE
Support custom indexing expression in search tags

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -328,13 +328,33 @@ class StructureProvider implements ProviderInterface
 
     private function getContentField(PropertyMetadata $property)
     {
+        $expression = $this->getExpression($property);
+
         $field = $this->factory->createMetadataExpression(
             sprintf(
-                'object.getStructure().%s.getValue()',
+                $expression,
                 $property->getName()
             )
         );
 
         return $field;
+    }
+
+    private function getExpression(PropertyMetadata $property)
+    {
+        // if this is a property of a block, it has no tags
+        $expression = 'object.getStructure().%s.getValue()';
+        if (!$property->hasTag('sulu.search.field')) {
+            return $expression;
+        }
+
+        $tag = $property->getTag('sulu.search.field');
+        $tagAttributes = $tag['attributes'];
+
+        if (isset($tagAttributes['expr'])) {
+            $expression = $tagAttributes['expr'];
+        }
+
+        return $expression;
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/default.xml
@@ -13,7 +13,9 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.rlp.part" priority="1"/>
         </property>
-        <property name="tags" type="tag_list"/>
+        <property name="tags" type="tag_list">
+            <tag name="sulu.search.field" expr="join(' ', map(object.getStructure().tags.getValue(), 'el.name'))" />
+        </property>
         <property name="url" type="resource_locator" mandatory="false">
             <tag name="sulu.rlp"/>
         </property>

--- a/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
+++ b/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
@@ -131,7 +131,7 @@ class StructureMetadataFactory implements StructureMetadataFactoryInterface
             $resources = [new FileResource($filePath)];
 
             $cache->write(
-                sprintf('<?php $metadata = \'%s\';', serialize($metadata)),
+                sprintf('<?php $metadata = <<<EOT' . PHP_EOL . '%s' . PHP_EOL . 'EOT' . PHP_EOL . ';', serialize($metadata)),
                 $resources
             );
         }


### PR DESCRIPTION
This PR adds a feature whereby the user may specify a custom expression to use when evaluating the value which will be indexed.

For example:

````xml
<?xml version="1.0" ?>
<template xmlns="http://schemas.sulu.io/template/template"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">

    <!-- ... -->
    <properties>
        <!-- ... -->
        <property name="tags" type="tag_list">
            <tag name="sulu.search.field" expr="join(' ', map(object.getStructure().tags.getValue(), 'el.name'))" />
        </property>
    </properties>
</template>
````

This provides extra flexibility, especially when values need to be determined from objects.