### PR TITLE
Fixed null value for smart content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1675 [ContactBundle]   Fixed null value for smart content
     * BUGFIX      #1667 [ContactBundle]   Removed the restriction of start dates from the datepicker
     * BUGFIX      #1671 [ContentBundle]   Fixed block sorting for blocks with only one type
     * BUGFIX      #1668 [ContentBundle]   Fixed smart content for usage with block property

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/validation/types/smartContent.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/validation/types/smartContent.js
@@ -35,10 +35,10 @@ define([
                 },
 
                 setValue: function(value) {
-                    var config;
-                    if (!!value.config) {
+                    var config = {};
+                    if (!!value && !!value.config) {
                         config = value.config;
-                    } else {
+                    } else if (!!value) {
                         config = value;
                     }
 


### PR DESCRIPTION
It only happens with a clean new install of sulu.

The homepage form cannot be loaded because no config (null) will be set to smart-content.

__tasks:__

- [ ] gather feedback for my changes


__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none