### PR TITLE
Support for Video-Stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #1697 [MediaBundle]     Replaced StreamedResponse with BinaryFileResponse
     * BUGFIX      #1696 [MediaBundle]     Fixed dropzone for uploading new versions of media
     * BUGFIX      #1675 [ContactBundle]   Fixed null value for smart content
     * FEATURE     #1653 [MediaBundle]     Added generation of thumbnails for videos

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -23,7 +23,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class MediaStreamController extends Controller
 {
@@ -68,7 +67,7 @@ class MediaStreamController extends Controller
      * @param Request $request
      * @param int $id
      *
-     * @return StreamedResponse
+     * @return BinaryFileResponse
      */
     public function downloadAction(Request $request, $id)
     {
@@ -104,7 +103,7 @@ class MediaStreamController extends Controller
      * @param string $locale
      * @param string $dispositionType
      *
-     * @return StreamedResponse
+     * @return BinaryFileResponse
      */
     protected function getFileResponse(
         $fileVersion,

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -120,16 +121,7 @@ class MediaStreamController extends Controller
 
         $path = $this->getStorage()->load($fileName, $version, $storageOptions);
 
-        $response = new StreamedResponse(function () use ($path) {
-            flush(); // send headers
-            $handle = fopen($path, 'r');
-            while (!feof($handle)) {
-                $buffer = fread($handle, 1024);
-                echo $buffer;
-                flush(); // buffered output
-            }
-            fclose($handle);
-        });
+        $response = new BinaryFileResponse($path);
 
         $pathInfo = pathinfo($fileName);
 


### PR DESCRIPTION
Replaced StreamedResponse with BinaryFileResponse.

StreamedResponse is not able to make use of the "range" header, which is needed to display videos inline.