### PR TITLE
removed logging for faster tests and lesser file errors

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -17,11 +17,8 @@ fos_rest:
 
 monolog:
     handlers:
-
         main:
-            type:  stream
-            path:  %kernel.logs_dir%/%kernel.environment%.log
-            level: debug
+            type: "null"
 
 sulu_core:
     cache_dir: %kernel.root_dir%/cache/sulu


### PR DESCRIPTION
Should reduce the probability of "Too many files open" errors, and will probably improve the test speed a bit. There is also no necessity of logs, since they won't be output anyway.

__tasks:__

- [ ] test coverage
- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | none
| Documentation PR | none