### PR TITLE
Added empty locale condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * ENHANCEMENT #1743 [SmartContent]    Fixed param names for website operators
     * FEATURE     #1739 [MediaBundle]     Implemented system collections
+    * BUGFIX      #1733 [ContentBundle]   Added empty locale condition to fix empty locale bug
     * BUGFIX      #1733 [ContactBundle]   Added delete warning and download icon for contact avatar and account logo
     * BUGFIX      #1733 [MediaBundle]     Fixed a few media-selection bugs
     * ENHANCEMENT #1605 [MediaBundle]     Adjust media-selection-overlay title

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
@@ -42,10 +42,6 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
      */
     private $encoder;
 
-    /**
-     * @param PropertyEncoder   $encoder
-     * @param DocumentInspector $inspector
-     */
     public function __construct(
         PropertyEncoder $encoder,
         DocumentInspector $inspector,
@@ -100,7 +96,7 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
      *
      * Note that this should happen before the fallback locale has been resolved
      *
-     * @param HydrateEvent $event
+     * @param AbstractMappingEvent $event
      */
     public function handleHydrate(AbstractMappingEvent $event)
     {
@@ -133,6 +129,10 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
         $document = $event->getDocument();
 
         if (!$document instanceof ShadowLocaleBehavior) {
+            return;
+        }
+
+        if (!$event->getLocale()) {
             return;
         }
 

--- a/tests/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriberTest.php
+++ b/tests/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriberTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Document\Subscriber;
+
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
+use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+
+class ShadowLocaleSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandlePersistEmptyLocale()
+    {
+        $encoder = $this->prophesize(PropertyEncoder::class);
+        $inspector = $this->prophesize(DocumentInspector::class);
+        $registry = $this->prophesize(DocumentRegistry::class);
+
+        $document = $this->prophesize(ShadowLocaleBehavior::class);
+        $document->isShadowLocaleEnabled()->shouldNotBeCalled();
+        $event = $this->prophesize(PersistEvent::class);
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getLocale()->willReturn(null);
+        $event->getNode()->shouldNotBeCalled();
+
+        $subscriber = new ShadowLocaleSubscriber($encoder->reveal(), $inspector->reveal(), $registry->reveal());
+
+        $subscriber->handlePersist($event->reveal());
+    }
+}


### PR DESCRIPTION
__tasks:__

- [x] test coverage
- [ ] gather feedback for my changes

__Related PR:__

* https://github.com/sulu-io/sulu-document-manager/pull/52

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | fixes #1704 
| BC breaks        | none
| Documentation PR | none