### PR TITLE
added missing joins to user to prevent lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #1760 [SecurityBundle]  Added missing joins on query for security
     * BUGFIX      #1750 [SecurityBundle]  Added seraialization groups for user
     * ENHANCEMENT #1754 [MediaBundle]     Moved collection key functions to base collection
     * BUGFIX      #1751 [Persistence]     Fixed UserBlameSubscriber for new DoctrineBundle

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Entity/UserRepositoryTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Entity/UserRepositoryTest.php
@@ -198,7 +198,7 @@ class UserRepositoryTest extends SuluTestCase
         $this->assertEquals('max.mustermann@muster.at', $user->getContact()->getEmails()[0]->getEmail());
     }
 
-    public function testfindUserByEmail()
+    public function testFindUserByEmail()
     {
         $this->prepareUser('sulu', 'sulu');
 
@@ -213,7 +213,7 @@ class UserRepositoryTest extends SuluTestCase
         $this->assertEquals('test', $user->getUsername());
     }
 
-    public function testfindUserByIdentifier()
+    public function testFindUserWithSecurityByIdentifier()
     {
         $this->prepareUser('sulu', 'sulu');
 
@@ -222,8 +222,8 @@ class UserRepositoryTest extends SuluTestCase
         /** @var UserRepository $userRepository */
         $userRepository = $client->getContainer()->get('sulu_security.user_repository_factory')->getRepository();
 
-        $userByMail = $userRepository->findUserByIdentifier('user2@test.com');
-        $userByUsername = $userRepository->findUserByIdentifier('test');
+        $userByMail = $userRepository->findUserWithSecurityByIdentifier('user2@test.com');
+        $userByUsername = $userRepository->findUserWithSecurityByIdentifier('test');
 
         $this->assertEquals('user2@test.com', $userByMail->getEmail());
         $this->assertEquals('test', $userByMail->getUsername());


### PR DESCRIPTION
That's actually an issue targeted at the 1.2 release, but I think we could also include it in 1.1, since it is not a big change.

__tasks:__

- [ ] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | fixes #1630 
| BC breaks        | none
| Documentation PR | none