### PR TITLE
fixed missing locale check for security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #1820 [ContentBundle]   Fixed migrate url script
+    * BUGFIX      #1815 [SecurityBundle]  Fixed missing locale check for security
     * BUGFIX      #1812 [ContactBundle]   Fixed translation bug in position dropdown
     * BUGFIX      #1814 [MediaBundle]     Fixed media selection bug
     * ENHANCEMENT #1806 [ContentBundle]   Fixed serialization depth for column-navigation

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -197,9 +197,13 @@ class AccessControlManager implements AccessControlManagerInterface
 
             $hasLocale = $locale == null || in_array($locale, $userRole->getLocales());
 
+            if (!$hasLocale) {
+                continue;
+            }
+
             if ($checkPermissionType) {
                 $userPermission = $this->maskConverter->convertPermissionsToArray($permission->getPermissions());
-            } elseif ($hasLocale) {
+            } else {
                 array_walk($userPermission, function (&$permission) {
                     $permission = true;
                 });

--- a/tests/Sulu/Component/Security/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/tests/Sulu/Component/Security/Authorization/AccessControl/AccessControlManagerTest.php
@@ -255,6 +255,13 @@ class AccessControlManagerTest extends \PHPUnit_Framework_TestCase
                 null,
                 ['view' => true, 'edit' => true],
             ],
+            [
+                [1 => ['view' => true, 'edit' => true]],
+                96,
+                ['en'],
+                'de',
+                ['view' => false, 'edit' => false],
+            ],
         ];
     }
 }


### PR DESCRIPTION
__tasks:__

- [x] test coverage
- [x] gather feedback for my changes

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| BC breaks        | Locale security works now as expected
| Documentation PR | none