### PR TITLE
fixed name of type map config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1846 [CoreBundle]      Fixed name of type map config parameter
     * BUGFIX      #1844 [ContactBundle]   Fixed dimensions and position of contact avatar
     * ENHANCEMENT #1843 [ContactBundle]   Added new field-descriptors for accounts and contacts (zip, state, country,..)
     * ENHANCEMENT #1842 [ContentBundle]   Fixed title generation to ignore checkboxes

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -250,7 +250,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
-                        ->arrayNode('typeMap')
+                        ->arrayNode('type_map')
                             ->isRequired()
                             ->useAttributeAsKey('name')
                             ->prototype('scalar')

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -197,7 +197,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu.content.structure.default_types', $contentConfig['structure']['default_type']);
         $container->setParameter('sulu.content.structure.default_type.snippet', $contentConfig['structure']['default_type']['snippet']);
         $container->setParameter('sulu.content.internal_prefix', $contentConfig['internal_prefix']);
-        $container->setParameter('sulu.content.structure.typeMap', $contentConfig['structure']['typeMap']);
+        $container->setParameter('sulu.content.structure.type_map', $contentConfig['structure']['type_map']);
 
         // Template
         $paths = [];

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -68,7 +68,7 @@
             <argument type="service" id="sulu_content.extension.manager" />
             <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu_content.compat.structure.legacy_property_factory" />
-            <argument>%sulu.content.structure.typeMap%</argument>
+            <argument>%sulu.content.structure.type_map%</argument>
         </service>
 
         <service id="sulu.content.webspace_structure_provider.cache" class="%sulu.content.webspace_structure_provider.cache.class%">

--- a/src/Sulu/Bundle/CoreBundle/Tests/DependencyInjection/SuluCoreExtensionTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/DependencyInjection/SuluCoreExtensionTest.php
@@ -32,7 +32,7 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
                         'snippet' => 'default',
                     ],
                     'paths' => [],
-                    'typeMap' => [
+                    'type_map' => [
                         'page' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
                         'home' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
                         'snippet' => '\Sulu\Component\Content\Compat\Structure\SnippetBridge',
@@ -62,7 +62,7 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
                         'snippet' => 'barfoo',
                     ],
                     'paths' => [],
-                    'typeMap' => [
+                    'type_map' => [
                         'page' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
                         'home' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
                         'snippet' => '\Sulu\Component\Content\Compat\Structure\SnippetBridge',
@@ -90,7 +90,7 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
                             'snippet' => 'barfoo',
                         ],
                         'paths' => [],
-                        'typeMap' => [
+                        'type_map' => [
                             'page' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
                             'home' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
                             'snippet' => '\Sulu\Component\Content\Compat\Structure\SnippetBridge',

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -44,7 +44,7 @@ sulu_core:
                      path: "%kernel.root_dir%/../../../CoreBundle/Content/templates"
                      type: "page"
 
-             typeMap:
+             type_map:
                  page: "\\Sulu\\Component\\Content\\Compat\\Structure\\PageBridge"
                  home: "\\Sulu\\Component\\Content\\Compat\\Structure\\PageBridge"
                  snippet: "\\Sulu\\Component\\Content\\Compat\\Structure\\SnippetBridge"


### PR DESCRIPTION
__tasks:__

- [ ] test coverage
- [ ] submit changes to the documentation

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | https://github.com/sulu-io/sulu-standard/pull/567
| BC breaks        | `sulu_core.content.structure.typeMap` is now `sulu_core.content.structure.type_map`
| Documentation PR | none