### PR TITLE
Added upgrade script which removes non-translated properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #1799 [ContentBundle]   Added 'published' field to be indexed
+    * HOTFIX      #1861 [ContentBundle]   Added upgrade script which removes non-translated properties
 
 * 1.1.1 (2015-12-07)
     * HOTFIX      #1857 [ContentBundle]   Fixed open ghost overlay

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade
 
+## dev-master
+
+### Reindex-Command
+
+Run the migrate command (`app/console phpcr:migrations:migrate`) to fix translated properties with non locale.
+
 ## 1.1.0
 
 ### IndexName decorators from MassiveSearchBundle

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201512090753.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201512090753.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle;
+
+use PHPCR\Migrations\VersionInterface;
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+
+/**
+ * Removes properties like 'i18n:-*'.
+ */
+class Version201512090753 implements VersionInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up(SessionInterface $session)
+    {
+        $root = $session->getRootNode();
+
+        $this->upgradeNode($root);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function down(SessionInterface $session)
+    {
+    }
+
+    /**
+     * Removes non translated properties.
+     *
+     * @param NodeInterface $node
+     */
+    private function upgradeNode(NodeInterface $node)
+    {
+        foreach ($node->getProperties('i18n:-*') as $property) {
+            $property->remove();
+        }
+
+        foreach ($node->getNodes() as $childNode) {
+            $this->upgradeNode($childNode);
+        }
+    }
+}


### PR DESCRIPTION
There are problems with the index-command if you have properties which looks like this: `i18n:-*` you get the error 

````
Error indexing or de-indexing page (path: ...) No structure type was available and no default exists for document with alias "home"
```

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | run `phpcr:migrations:migrate`
| Documentation PR | none