### PR TITLE
used auto_name in phpcr migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #1888 [ContentBundle]   used auto_name in phpcr migrations
+
 * 1.1.2 (2015-12-11)
     * HOTFIX      #1831 [MediaBundle]     Fixed query for retrieving entities to index
     * HOTFIX      #1868 [ContentBundle]   Added date upgrade script for blocks

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240843.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240843.php
@@ -229,7 +229,7 @@ class Version201511240843 implements VersionInterface, ContainerAwareInterface
             }
         }
 
-        $this->documentManager->persist($document, $locale);
+        $this->documentManager->persist($document, $locale, ['auto_name' => false]);
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240844.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240844.php
@@ -265,7 +265,7 @@ class Version201511240844 implements VersionInterface, ContainerAwareInterface
             }
         }
 
-        $this->documentManager->persist($document, $locale);
+        $this->documentManager->persist($document, $locale, ['auto_name' => false]);
     }
 
     /**


### PR DESCRIPTION
The phpcr migrations had problems with the automatic renaming of nodes,
so there we make use of the new auto_name option, so that we can disable
that.

@wachterjohannes That should probably be used in all migrations in the
future.

__tasks:__

- [x] test coverage

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | https://github.com/sulu-io/sulu-document-manager/pull/56
| BC breaks        | none
| Documentation PR | none