### PR TITLE
fix default locale user builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1911 [SecurityBundle]  Fixed default locale user builder
     * FEATURE     #1905 [All]             Added french translation
     * BUGFIX      #1893 [ContentBundle]   Fixed resource locator deferred for edit
     * BUGIFX      #1871 [ContentBundle]   Fixed url-generation and save button

--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -43,8 +43,10 @@ class UserBuilder extends SuluBuilder
         $password = 'admin';
         $roleName = 'User';
         $system = 'Sulu';
+        $locale = 'de';
         $doctrine = $this->container->get('doctrine')->getManager();
         $userRep = $this->container->get('sulu.repository.user');
+        $userLocales = $this->container->getParameter('sulu_core.locales');
 
         $existing = $userRep->findOneByUsername($user);
 
@@ -69,6 +71,11 @@ class UserBuilder extends SuluBuilder
             sprintf('Created role "<comment>%s</comment>" in system "<comment>%s</comment>"', $roleName, $system)
         );
 
+        //locale choosen doesn't exist, fallback
+        if (!in_array($locale, $userLocales)) {
+            $locale = array_shift($userLocales);
+        }
+
         $this->execCommand(
             'Creating user: ' . $user,
             'sulu:security:user:create',
@@ -77,7 +84,7 @@ class UserBuilder extends SuluBuilder
                 'firstName' => 'Adam',
                 'lastName' => 'Ministrator',
                 'email' => 'admin@example.com',
-                'locale' => 'de',
+                'locale' => $locale,
                 'role' => $roleName,
                 'password' => $password,
             ]

--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -71,7 +71,7 @@ class UserBuilder extends SuluBuilder
             sprintf('Created role "<comment>%s</comment>" in system "<comment>%s</comment>"', $roleName, $system)
         );
 
-        //locale choosen doesn't exist, fallback
+        // locale choosen doesn't exist, fallback
         if (!in_array($locale, $userLocales)) {
             $locale = array_shift($userLocales);
         }


### PR DESCRIPTION
fix default locale user builder :

Hardcoded locale `de` into user builder, but when `de` is not defined into 
```
sulu_core:
    locales:
        fr: Francais
        en: English
```
leads error in command `sulu:build` and user is not created.

__tasks:__

- [ x ] Fix it 

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | none
| Documentation PR | none