### PR TITLE
removed unnecessary index definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #1944 [MediaBundle]     Removed wrong definition of indices
     * ENHANCEMENT #1936 [Webspace]        Cleanup of WebsiteRequestAnalyzer
     * ENHANCEMENT #1937 [WebsiteBundle]   Removed unnecessary ob_clean in WebsiteController
     * BUGFIX      #1931 [ContentBundle]   Fixed form deprecation messages   

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/BaseCollection.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/BaseCollection.orm.xml
@@ -5,10 +5,6 @@
                   xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
 
     <mapped-superclass name="Sulu\Bundle\MediaBundle\Entity\BaseCollection">
-        <indexes>
-            <index name="key_idx" columns="collection_key" />
-        </indexes>
-
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionType.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionType.orm.xml
@@ -3,10 +3,6 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Sulu\Bundle\MediaBundle\Entity\CollectionType" table="me_collection_types">
-        <indexes>
-            <index name="key_idx" columns="collection_type_key" />
-        </indexes>
-
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>


### PR DESCRIPTION
The given index definitions are not neccessary, because the fields mentioned there are already marked unique, and therefore are already indexed. In addition to that the index name `key_idx` was used twice. That caused postgresql to throw the error mentioned in https://github.com/sulu-io/sulu-standard/issues/584. MySQL doesn't seem to bother about this error.

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | fixes https://github.com/sulu-io/sulu-standard/issues/584
| Related PRs      | none
| BC breaks        | works better with postgres now :wink:
| Documentation PR | none