### PR TITLE
Added possibility to disable the GROUP BY clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #1950 [Rest]            Added possibility to disable the GROUP BY clause     
+
 * 1.1.6 (2016-01-26)
     * HOTFIX      #1948 [AdminBundle]     Updated husky for required validation fix
     * HOTFIX      #1938 [ContactBundle]   Added missing namespace declerations for fixtures

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -279,7 +279,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         $addJoins = $this->getNecessaryJoins($entityNames);
 
         // create querybuilder and add select
-        return $this->createQueryBuilder($addJoins)
+        return $this->createQueryBuilder($addJoins, false)
             ->select($select);
     }
 
@@ -358,10 +358,11 @@ class DoctrineListBuilder extends AbstractListBuilder
      * Creates Querybuilder.
      *
      * @param array|null $joins Define which joins should be made
+     * @param bool|true $groupBy Defines if the GROUP BY clause should be added
      *
      * @return \Doctrine\ORM\QueryBuilder
      */
-    protected function createQueryBuilder($joins = null)
+    protected function createQueryBuilder($joins = null, $groupBy = true)
     {
         $this->queryBuilder = $this->em->createQueryBuilder()
             ->from($this->entityName, $this->entityName);
@@ -376,7 +377,9 @@ class DoctrineListBuilder extends AbstractListBuilder
         }
 
         // group by
-        $this->assignGroupBy($this->queryBuilder);
+        if (true === $groupBy) {
+            $this->assignGroupBy($this->queryBuilder);
+        }
 
         if ($this->search != null) {
             $searchParts = [];

--- a/tests/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/tests/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -633,7 +633,7 @@ class DoctrineListBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->doctrineListBuilder->addGroupBy($nameFieldDescriptor);
 
-        $this->queryBuilder->expects($this->at(1))->method('groupBy')->with(self::$entityName . '.name');
+        $this->queryBuilder->expects($this->once())->method('groupBy')->with(self::$entityName . '.name');
 
         $this->doctrineListBuilder->execute();
     }


### PR DESCRIPTION
Disable the GROUP BY clause for ID- and COUNT-Select (Performance)

__tasks:__

- [ ] test coverage


__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | none
| Documentation PR | none