### PR TITLE
[FEATURE] Clear local image cache via cache clear service and command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #2001 [MediaBundle]         Clear local image cache via cache clear service and command
     * BUGFIX      #1986 [All]                 Fixed naming of serializer properties
     * BUGFIX      #1985 [CollaborationBundle] Removed leaking connections
     * ENHANCEMENT #1973 [All]                 Moved tests from /tests to component directories.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## dev-develop
 
+### Media uploads
+
+Write permissions for the webserver must be set on `web/uploads` instead of
+`web/uploads/media` alone to support simple cache clearing.
+
 ### Admin Commands
 
 The method `getCommands` on the Admin has been removed, because Symfony can

--- a/src/Sulu/Bundle/MediaBundle/Command/ClearCacheCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/ClearCacheCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Command;
+
+use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearerInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Clears the media cache.
+ */
+class ClearCacheCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this->setName('sulu:media:format:cache:clear')
+            ->setDescription('Clear all or the given Sulu media format cache')
+            ->addArgument('cache', InputArgument::OPTIONAL, 'Optional alias to clear the specific cache')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var FormatCacheClearerInterface $cacheClearer */
+        $cacheClearer = $this->getContainer()->get('sulu_media.format_cache_clearer');
+        $cache = $input->getArgument('cache');
+
+        $output->writeln('Clearing the Sulu media format cache.');
+        $cacheClearer->clear($cache);
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/FormatCacheClearerCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/FormatCacheClearerCompilerPass.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Registers the format cache clearers.
+ */
+class FormatCacheClearerCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('sulu_media.format_cache_clearer')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('sulu_media.format_cache_clearer');
+        $taggedServices = $container->findTaggedServiceIds('sulu_media.format_cache');
+
+        foreach ($taggedServices as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $definition->addMethodCall(
+                    'add',
+                    [new Reference($id), $attributes['alias']]
+                );
+            }
+        }
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/CacheNotFoundException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/CacheNotFoundException.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\Exception;
+
+/**
+ * This Exception is thrown when the wanted format cache was not found.
+ */
+class CacheNotFoundException extends MediaException
+{
+    private $alias;
+
+    /**
+     * @param string $alias
+     */
+    public function __construct($alias)
+    {
+        $this->alias = $alias;
+
+        parent::__construct('Format cache with the alias ' . $alias . ' was not found', self::EXCEPTION_CACHE_NOT_FOUND);
+    }
+
+    /**
+     * The format cache alias which is not found.
+     *
+     * @return string
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    public function toArray()
+    {
+        return [
+            'code' => $this->code,
+            'message' => $this->message,
+            'alias' => $this->alias,
+        ];
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/MediaException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/MediaException.php
@@ -166,6 +166,13 @@ class MediaException extends Exception
     const EXCEPTION_CODE_FILE_NOT_FOUND = 5021;
 
     /**
+     * Format cache is not found.
+     *
+     * @var int
+     */
+    const EXCEPTION_CACHE_NOT_FOUND = 5022;
+
+    /**
      * Systemfile is not found.
      *
      * @var int

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheClearer.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheClearer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\FormatCache;
+
+use Sulu\Bundle\MediaBundle\Media\Exception\CacheNotFoundException;
+
+/**
+ * Format cache clearer.
+ */
+class FormatCacheClearer implements FormatCacheClearerInterface
+{
+    /**
+     * @var FormatCacheInterface[]
+     */
+    private $caches = [];
+
+    /**
+     * Clear all or the given cache.
+     *
+     * @param string $cache The alias of the cache
+     *
+     * @throws CacheNotFoundException if the cache is not found
+     */
+    public function clear($cache = null)
+    {
+        if (null !== $cache) {
+            if (!array_key_exists($cache, $this->caches)) {
+                throw new CacheNotFoundException($cache);
+            }
+
+            $this->caches[$cache]->clear();
+        } else {
+            foreach ($this->caches as $cache) {
+                $cache->clear();
+            }
+        }
+    }
+
+    /**
+     * Adds a cache to the aggregate.
+     *
+     * @param FormatCacheInterface $cache The cache
+     * @param string $alias The cache alias
+     */
+    public function add(FormatCacheInterface $cache, $alias)
+    {
+        $this->caches[$alias] = $cache;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheClearerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheClearerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\FormatCache;
+
+use Sulu\Bundle\MediaBundle\Media\Exception\CacheNotFoundException;
+
+/**
+ * Format cache clearer.
+ */
+interface FormatCacheClearerInterface
+{
+    /**
+     * Clear all or the given cache.
+     *
+     * @param string $cache The alias of the cache
+     *
+     * @throws CacheNotFoundException if the cache is not found
+     */
+    public function clear($cache = null);
+}

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheInterface.php
@@ -62,4 +62,9 @@ interface FormatCacheInterface
      * @return array ($id, $format)
      */
     public function analyzedMediaUrl($url);
+
+    /**
+     * Clears the format cache.
+     */
+    public function clear();
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
@@ -99,6 +99,27 @@ class LocalFormatCache implements FormatCacheInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        $realCacheDir = $this->path;
+        $oldCacheDir = $realCacheDir . '_old';
+
+        if (!is_writable($realCacheDir)) {
+            throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $realCacheDir));
+        }
+
+        if ($this->filesystem->exists($oldCacheDir)) {
+            $this->filesystem->remove($oldCacheDir);
+        }
+
+        $this->filesystem->rename($realCacheDir, $oldCacheDir);
+        $this->filesystem->mkdir($realCacheDir);
+        $this->filesystem->remove($oldCacheDir);
+    }
+
+    /**
      * @param string $prePath
      * @param int    $id
      * @param string $fileName

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -570,6 +570,14 @@ class FormatManager implements FormatManagerInterface
     }
 
     /**
+     * Clears the format cache.
+     */
+    public function clearCache()
+    {
+        $this->formatCache->clear();
+    }
+
+    /**
      * @param $mimeType
      *
      * @return bool

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -59,4 +59,9 @@ interface FormatManagerInterface
      * @return bool
      */
     public function purge($idMedia, $fileName, $options);
+
+    /**
+     * Clears the format cache.
+     */
+    public function clearCache();
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <parameter key="sulu_media.storage.class">Sulu\Bundle\MediaBundle\Media\Storage\LocalStorage</parameter>
         <parameter key="sulu_media.file_validator.class">Sulu\Bundle\MediaBundle\Media\FileValidator\FileValidator</parameter>
         <parameter key="sulu_media.format_manager.class">Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManager</parameter>
+        <parameter key="sulu_media.format_cache_clearer.class">Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearer</parameter>
         <parameter key="sulu_media.format_cache.class">Sulu\Bundle\MediaBundle\Media\FormatCache\LocalFormatCache</parameter>
         <parameter key="sulu_media.image.converter.class">Sulu\Bundle\MediaBundle\Media\ImageConverter\ImagineImageConverter</parameter>
         <parameter key="sulu_media.image.command_manager.class">Sulu\Bundle\MediaBundle\Media\ImageConverter\Command\Manager\CommandManager</parameter>
@@ -62,13 +63,17 @@
             <argument type="service" id="logger"/>
         </service>
         <service id="sulu_media.file_validator" class="%sulu_media.file_validator.class%" />
+
+        <service id="sulu_media.format_cache_clearer" class="%sulu_media.format_cache_clearer.class%" />
         <service id="sulu_media.format_cache" class="%sulu_media.format_cache.class%">
             <argument type="service" id="filesystem"/>
             <argument>%sulu_media.format_cache.path%</argument>
             <argument>%sulu_media.format_cache.media_proxy_path%</argument>
             <argument>%sulu_media.format_cache.segments%</argument>
             <argument>%sulu_media.image.formats%</argument>
+            <tag name="sulu_media.format_cache" alias="local" />
         </service>
+
         <service id="sulu_media.image.converter" class="%sulu_media.image.converter.class%">
             <argument type="service" id="sulu_media.image.command_manager" />
         </service>

--- a/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
+++ b/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle;
 
+use Sulu\Bundle\MediaBundle\DependencyInjection\FormatCacheClearerCompilerPass;
 use Sulu\Bundle\MediaBundle\DependencyInjection\ImageCommandCompilerPass;
 use Sulu\Bundle\MediaBundle\DependencyInjection\ImageFormatCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,6 +23,7 @@ class SuluMediaBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new FormatCacheClearerCompilerPass());
         $container->addCompilerPass(new ImageFormatCompilerPass());
         $container->addCompilerPass(new ImageCommandCompilerPass());
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/FormatCacheClearerCompilerPassTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/FormatCacheClearerCompilerPassTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sulu\Bundle\MediaBundle\DependencyInjection\FormatCacheClearerCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Test the image command compiler pass.
+ */
+class FormatCacheClearerCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new FormatCacheClearerCompilerPass());
+    }
+
+    public function testFormatCacheTag()
+    {
+        $formatCacheClearer = new Definition();
+        $this->setDefinition('sulu_media.format_cache_clearer', $formatCacheClearer);
+
+        $formatCache = new Definition();
+        $formatCache->addTag('sulu_media.format_cache', [
+            'alias' => 'local',
+        ]);
+        $this->setDefinition('sulu_media.format_cache', $formatCache);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sulu_media.format_cache_clearer',
+            'add',
+            [
+                new Reference('sulu_media.format_cache'),
+                'local',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Simply renames the cache dir, deletes it as a whole and creates a new one. The command name is `sulu:media:cache:clear`

__tasks:__

- [x] Move cache clear into the dedicated format caches and execute them
- [x] Add entry to `CHANGELOG.md`
- [x] Add entry to `UPGRADE.md`
- [x] Update documentation

__informations:__

| q             | a
| ------------- | ---
| Fixed tickets | fixes #808 
| Related PRs | #1052 
| BC Breaks     | Webserver write permissions must be set on `web/uploads` instead of `web/uploads/media`
| Documentation PR | sulu-io/sulu-docs#166

Reopens #1052 as the branch was deleted by accident and GitHub no longer allows reopening it after rebase :dizzy_face: 