### PR TITLE
[HOTFIX] Fixed retina height for image scale command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2002 [MediaBundle]       Fixed retina height for image scale command
     * HOTFIX      #2003 [ContactBundle]     Fixed rendering of address with null title
     * HOTFIX     #1991   [Rest]             Added metadata for field-descriptors
     

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Command/ScaleCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Command/ScaleCommand.php
@@ -48,7 +48,7 @@ class ScaleCommand implements CommandInterface
         // retina x2
         if ($parameters['retina']) {
             $newWidth = $parameters['x'] * 2;
-            $newHeight = $parameters['x'] * 2;
+            $newHeight = $parameters['y'] * 2;
         }
 
         // calculate height when not set

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Command/ScaleCommandTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Command/ScaleCommandTest.php
@@ -36,6 +36,18 @@ class ScaleCommandTest extends AbstractCommandTest
             [
                 // Command Options
                 'options' => [
+                        'x' => 200,
+                        'y' => 100,
+                        'forceRatio' => false,
+                        'retina' => true,
+                    ],
+                // Tested Result
+                'width' => 400,
+                'height' => 200,
+            ],
+            [
+                // Command Options
+                'options' => [
                         'x' => 5000,
                         'y' => 5000,
                         'forceRatio' => true,


### PR DESCRIPTION
The image scale command used the `x` parameter for duplicating the new height instead of the `y` parameter if the `retina` option is true.

__tasks:__

- [x] Fix image scale command
- [x] Add test for retina option with correct width and height
- [x] Add to `CHANGELOG.md`


__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | n/a
| Related PRs      | n/a
| BC breaks        | none
| Documentation PR | n/a