### PR TITLE
[HOTFIX] Merge Twig globals and add output buffer handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2005 [WebsiteBundle]     Merge Twig globals and add output buffer handling for preview rendering
     * HOTFIX      #2003 [ContactBundle]     Fixed rendering of address with null title
     * HOTFIX     #1991   [Rest]             Added metadata for field-descriptors
     

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -90,8 +90,24 @@ abstract class WebsiteController extends Controller
     protected function renderBlock($template, $block, $attributes = [])
     {
         $twig = $this->get('twig');
+        $attributes = $twig->mergeGlobals($attributes);
+
+        /** @var \Twig_Template $template */
         $template = $twig->loadTemplate($template);
 
-        return $template->renderBlock($block, $attributes);
+        $level = ob_get_level();
+        ob_start();
+        try {
+            $rendered = $template->renderBlock($block, $attributes);
+            ob_end_clean();
+
+            return $rendered;
+        } catch (\Exception $e) {
+            while (ob_get_level() > $level) {
+                ob_end_clean();
+            }
+
+            throw $e;
+        }
     }
 }


### PR DESCRIPTION
Merge Twig globals and add output buffer handling for rendering blocks in preview and other locations. Twigs `renderBlock()` is an internal method and thus the call must be wrapped into proper output buffer handling.

See twigphp/Twig#676

__tasks:__

- [x] Merge Twig globals and add output buffer handling
- [x] Add to `CHANGELOG.md`


__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | n/a
| Related PRs      | n/a
| BC breaks        | none
| Documentation PR | n/a