### PR TITLE
set user language for request in backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG for Sulu
     * HOTFIX      #1991 [Rest]              Added metadata for field-descriptors
     * BUGFIX      #1944 [MediaBundle]       Removed wrong definition of indices
     * HOTFIX      #2011 [AdminBundle]       Fixed double handling of login via enter
+    * HOTFIX      #2023 [SecurityBundle]    Set the user language for requests in backend
     
 * 1.1.9 (2016-02-05)
     * ENHANCEMENT #1978 [SecurityBundle]    Made url for resetting password configurable via static variable

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/UserLocaleListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/UserLocaleListener.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\EventListener;
+
+use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Sets the locale of the current User to the request. Required for the translator to work properly.
+ */
+class UserLocaleListener
+{
+    /**
+     * TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * Sets the locale of the current User to the request, if a User is logged in.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function copyUserLocaleToRequest(GetResponseEvent $event)
+    {
+        $token = $this->tokenStorage->getToken();
+        if (!$token) {
+            return;
+        }
+
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return;
+        }
+
+        $event->getRequest()->setLocale($user->getLocale());
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -157,5 +157,11 @@
             <tag name="jms_serializer.event_subscriber" />
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <service id="sulu_security.event_listener.user" class="Sulu\Bundle\SecurityBundle\EventListener\UserLocaleListener">
+            <argument type="service" id="security.token_storage"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="copyUserLocaleToRequest"/>
+            <tag name="sulu.context" context="admin"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/UserLocaleListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/UserLocaleListenerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\EventListener;
+
+use Prophecy\Argument;
+use Sulu\Bundle\SecurityBundle\EventListener\UserLocaleListener;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var UserInterface
+     */
+    private $user;
+
+    /**
+     * @var TokenInterface
+     */
+    private $token;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var GetResponseEvent
+     */
+    private $event;
+
+    /**
+     * @var UserLocaleListener
+     */
+    private $userLocaleListener;
+
+    public function setUp()
+    {
+        $this->request = $this->prophesize(Request::class);
+        $this->event = $this->prophesize(GetResponseEvent::class);
+        $this->event->getRequest()->willReturn($this->request->reveal());
+
+        $this->token = $this->prophesize(TokenInterface::class);
+
+        $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
+        $this->tokenStorage->getToken()->willReturn($this->token->reveal());
+
+        $this->userLocaleListener = new UserLocaleListener($this->tokenStorage->reveal());
+    }
+
+    public function testCopyUserLocaleToRequestWithoutUser()
+    {
+        $this->request->setLocale(Argument::any())->shouldNotBeCalled();
+        $this->userLocaleListener->copyUserLocaleToRequest($this->event->reveal());
+    }
+
+    public function testCopyUserLocaleToRequest()
+    {
+        $user = $this->prophesize(UserInterface::class);
+        $user->getLocale()->willReturn('de');
+        $this->token->getUser()->willReturn($user);
+
+        $this->request->setLocale('de')->shouldBeCalled();
+        $this->userLocaleListener->copyUserLocaleToRequest($this->event->reveal());
+    }
+}


### PR DESCRIPTION
__tasks:__

- [x] test coverage

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | The language of the requests have the user language instead of the default one
| Documentation PR | none