### PR TITLE
Added structure type to index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2035 [ContentBundle]       Add structure type to index
     * BUGFIX      #2058 [ListBuilder]         Fixed cache for field-descriptor
     * ENHANCEMENT #2034 [ContentBundle]       Improved content-bundle testcases
     * ENHANCEMENT #2036 [SecurityBundle]      Introduced different permission types for different security contexts

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,6 +45,14 @@ public function getSecurityContexts()
 By default, we will enable the permission types `VIEW`, `ADD`, `EDIT`, `DELETE`
 and `SECURITY` in your context.
 
+### Page search index
+
+The metadata for pages has changed. Run following command to update your search index
+
+```bash
+sf massive:search:index:rebuild
+```
+
 ### Media uploads
 
 Write permissions for the webserver must be set on `web/uploads` instead of

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -244,7 +244,7 @@ class StructureProvider implements ProviderInterface
             [
                 'type' => 'string',
                 'stored' => true,
-                'indexed' => false,
+                'indexed' => true,
                 'field' => $this->factory->createMetadataProperty('structureType'),
             ]
         );


### PR DESCRIPTION
This PR enables indexing of the structure-type. It can be used to search for specific page page. 

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | YES reindex to use this feature
| Documentation PR | none