### PR TITLE
Added metadata property to serialization process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG for Sulu
     * HOTFIX      #2074 [ListBuilder]       Added options for creating field-descriptors with meta-data
     * HOTFIX      #2053 [ContactBundle]     Added 'hasEmail' parameter to accounts api
     * HOTFIX      #2064 [ResourceBundle]    Fixed no option for invalid filter
+    * HOTFIX      #2051 [ListBuilder]       Added metadata property to serialization process
     * HOTFIX      #2055 [ContactBundle]     Replaced span by input type hidden in address form
     * HOTFIX      #2058 [ListBuilder]       Fixed cache for field-descriptor
     * HOTFIX      #2024 [ContactBundle]     Fixed account add-contact-overlay enter bug and search for e-mail

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/PropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/PropertyMetadata.php
@@ -20,7 +20,7 @@ class PropertyMetadata extends BasePropertyMetadata
     /**
      * @var BasePropertyMetadata[]
      */
-    private $metadata = [];
+    protected $metadata = [];
 
     /**
      * @return BasePropertyMetadata[]
@@ -57,5 +57,32 @@ class PropertyMetadata extends BasePropertyMetadata
     public function has($name)
     {
         return array_key_exists($name, $this->metadata);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize(
+            [
+                $this->class,
+                $this->name,
+                $this->metadata,
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($str)
+    {
+        list($this->class,
+            $this->name,
+            $this->metadata) = unserialize($str);
+
+        $this->reflection = new \ReflectionProperty($this->class, $this->name);
+        $this->reflection->setAccessible(true);
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/VirtualPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/VirtualPropertyMetadata.php
@@ -30,6 +30,7 @@ class VirtualPropertyMetadata extends PropertyMetadata
             [
                 $this->class,
                 $this->name,
+                $this->metadata,
             ]
         );
     }
@@ -39,6 +40,8 @@ class VirtualPropertyMetadata extends PropertyMetadata
      */
     public function unserialize($str)
     {
-        list($this->class, $this->name) = unserialize($str);
+        list($this->class,
+            $this->name,
+            $this->metadata) = unserialize($str);
     }
 }

--- a/tests/Sulu/Component/Rest/ListBuilder/Metadata/PropertyMetadataTest.php
+++ b/tests/Sulu/Component/Rest/ListBuilder/Metadata/PropertyMetadataTest.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Metadata;
+
+use JMS\Serializer\Metadata\PropertyMetadata as BasePropertyMetadata;
+
+class PropertyMetadataTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSerialize()
+    {
+        $metadata = new PropertyMetadata(PropertyMetadataTestTestClass::class, 'test');
+        $metadata->addMetadata('Test', new BasePropertyMetadata(PropertyMetadataTestTestClass::class, 'test'));
+
+        $this->assertEquals($metadata, unserialize(serialize($metadata)));
+    }
+}
+
+class PropertyMetadataTestTestClass
+{
+    public $test;
+}

--- a/tests/Sulu/Component/Rest/ListBuilder/Metadata/VirtualPropertyMetadataTest.php
+++ b/tests/Sulu/Component/Rest/ListBuilder/Metadata/VirtualPropertyMetadataTest.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Metadata;
+
+use JMS\Serializer\Metadata\PropertyMetadata as BasePropertyMetadata;
+
+class VirtualPropertyMetadataTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSerialize()
+    {
+        $metadata = new VirtualPropertyMetadata(PropertyMetadataTestTestClass::class, 'test');
+        $metadata->addMetadata('Test', new BasePropertyMetadata(PropertyMetadataTestTestClass::class, 'test'));
+
+        $this->assertEquals($metadata, unserialize(serialize($metadata)));
+    }
+}
+
+class VirtualPropertyMetadataTestTestClass
+{
+    public $test;
+}


### PR DESCRIPTION
If you load the cached field-descriptors you get the wrong response (e.g. no display property and wrong `filter-type`) because the `GeneralMetadataSerializeSubscriber` (https://github.com/sulu-io/sulu/blob/develop/src/Sulu/Component/Rest/ListBuilder/Metadata/Listener/GeneralMetadataSerializeSubscriber.php#L53) get null from the metadata and not appends the values from the `PropertyMetadata`.

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | none
| Documentation PR | none