### PR TITLE
Added options for creating field-descriptors with meta-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2074 [ListBuilder]       Added options for creating field-descriptors with meta-data
     * HOTFIX      #2053 [ContactBundle]     Added 'hasEmail' parameter to accounts api
     * HOTFIX      #2055 [ContactBundle]     Replaced span by input type hidden in address form
     * HOTFIX      #2058 [ListBuilder]       Fixed cache for field-descriptor

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/Driver/XmlDriver.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/Driver/XmlDriver.php
@@ -262,11 +262,11 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
         }
 
         if (null !== $condition = XmlUtil::getValueFromXPath('orm:condition', $xpath, $joinNode)) {
-            $joinMetadata->setCondition($condition);
+            $joinMetadata->setCondition($this->resolveParameter($condition));
         }
 
         if (null !== $conditionMethod = XmlUtil::getValueFromXPath('orm:condition-method', $xpath, $joinNode)) {
-            $joinMetadata->setConditionMethod($conditionMethod);
+            $joinMetadata->setConditionMethod($this->resolveParameter($conditionMethod));
         }
 
         if (null !== $method = XmlUtil::getValueFromXPath('orm:method', $xpath, $joinNode)) {

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactoryInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactoryInterface.php
@@ -21,8 +21,9 @@ interface FieldDescriptorFactoryInterface
      * Return field-descriptors for given class.
      *
      * @param string $className
+     * @param array $options
      *
      * @return FieldDescriptorInterface[]
      */
-    public function getFieldDescriptorForClass($className);
+    public function getFieldDescriptorForClass($className, $options = []);
 }

--- a/tests/Sulu/Component/Rest/ListBuilder/Metadata/Resources/options.xml
+++ b/tests/Sulu/Component/Rest/ListBuilder/Metadata/Resources/options.xml
@@ -1,0 +1,19 @@
+<class xmlns="http://schemas.sulu.io/class/general"
+       xmlns:list="http://schemas.sulu.io/class/list"
+       xmlns:orm="http://schemas.sulu.io/class/doctrine">
+    <properties>
+        <property name="city">
+            <orm:field-name>city</orm:field-name>
+            <orm:entity-name>SuluContactBundle:Address</orm:entity-name>
+
+            <orm:joins>
+                <orm:join>
+                    <orm:entity-name>SuluContactBundle:ContactAddress</orm:entity-name>
+                    <orm:field-name>%sulu.model.contact.class%.contactAddresses</orm:field-name>
+                    <orm:method>LEFT</orm:method>
+                    <orm:condition>SuluContactBundle:ContactAddress.locale = ':locale'</orm:condition>
+                </orm:join>
+            </orm:joins>
+        </property>
+    </properties>
+</class>


### PR DESCRIPTION
You can use `:locale` and the `$options` parameter to use request params in the metadata.

__tasks:__

- [x] test coverage

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | none
| Documentation PR | none