### PR TITLE
Add a meaningful pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+| Q | A
+| --- | ---
+| Bug fix? | [yes|no]
+| New feature? | [yes|no]
+| BC breaks? | [yes|no]
+| Deprecations? | [yes|no]
+| Fixed tickets | [Example: fixes #123, fixes #456]
+| Related PRs | [Example: #345, #789]
+| License | MIT
+| Documentation PR | [Example: sulu-io/sulu-docs#123 - leave empty if not needed]
+
+#### TODO
+
+If you can't meet the requirements of the checklist above, create a short to-do
+list and add the relevant parts:
+
+- [ ] Submit changes to the documentation
+- [ ] Document the BC breaks
+
+If the code is not finished yet because you don't have time to finish it or
+because you want early feedback on your work, add an item to the to-do list:
+
+- [ ] Finish the code
+- [ ] Add tests as they have not been updated yet
+- [ ] Gather feedback for my changes
+
+As long as you have items in the to-do list, please prefix the pull request
+title with `[WIP]`.
+Remove the TODO section if your pull request is complete and has no tasks.
+
+#### Description
+
+Add as much details as possible about your changes (don't hesitate to give code
+examples to illustrate your points). The pull request description helps the code
+review and it serves as a reference when the code is merged.
+
+#### Purpose
+
+If your pull request is about adding a new feature or modifying an existing one,
+explain the rationale for the changes. Why you added this feature, or why you
+have done the changes in the way you did?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,9 @@ Contributing
 Sulu CMF is an open source, community-driven project. We follow the same coding
 standards as Symfony.
 
-Before making a pull request please ensure you use the [Pull Request
+Before making a pull request please ensure you fill out the [Pull Request
 Template](http://docs.sulu.io/en/latest/developer/contributing/pull-requests.html#template)
+pre filled by GitHub accordingly.
 
 Useful links:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | n/a
| Fixed tickets | none
| License | MIT
| Doc PR | sulu-io/sulu-docs#180

#### TODO

- [x] Update the contributing docs

#### Description

This PR adds a meaningful pull request template, which defines a structure to encourage high quality PRs, which are understandable for new collaborators at every time. This supersedes and closes #2021 too.

The license is required to make sure all contributions are licensed under MIT. Otherwise it is a little bit unsure, which license a contribution has.
Another solution would be to require signing contribution license agreements, but IMHO the license line in the PR should be preferred.

#### Purpose

Most of the PRs in this repo have less or no description at all. Thus it is very hard to follow the changes as an outside collaborator. And as @webmozart is already questioning most of the issues and pull requests to add a meaningful description, this is the next logical step.