### PR TITLE
[All] Get rid of the aliased evenement composer constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2082 [All]                 Get rid of the aliased evenement composer constraint
     * ENHANCEMENT #2035 [ContentBundle]       Add structure type to index
     * BUGFIX      #2058 [ListBuilder]         Fixed cache for field-descriptor
     * ENHANCEMENT #2034 [ContentBundle]       Improved content-bundle testcases

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "willdurand/hateoas-bundle": "0.3.*",
         "symfony/swiftmailer-bundle": "~2.3",
         "pagerfanta/pagerfanta": "~1.0",
-        "evenement/evenement": "2.0.0 as 1.0.0",
         "pulse00/ffmpeg-bundle": "^0.5.2",
         "oro/doctrine-extensions": "^1.0"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | none
| Related PRs | sulu-io/sulu-standard#626
| License | MIT
| Documentation PR | none

#### Description

With the new `react/socket` release 0.4.3 which requires again `evenement/evenemt: ^2.0|^1.0` it's possible to get rid of the aliased statement in Sulu itself.

#### Purpose

Such an easy pick with the new react release, after I begun to clean up the libs which require the v1.0 :weary: