### PR TITLE
Fixed maximum length of category-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2094 [CategoryBundle]      Fixed maximum length of category-key
     * ENHANCEMENT #2082 [All]                 Get rid of the aliased evenement composer constraint
     * ENHANCEMENT #2035 [ContentBundle]       Add structure type to index
     * BUGFIX      #2058 [ListBuilder]         Fixed cache for field-descriptor

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,14 @@
 
 ## dev-develop
 
+### Category-Key
+
+Length of category-key column was extended. Use following command to update the schema definition.
+
+```bash
+app/console doctrine:schema:update --force
+```
+
 ### Definition of security contexts
 
 The definition of security contexts in the `Admin` classes has changed. They

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\CategoryBundle\Category;
 
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
 use Sulu\Bundle\CategoryBundle\Category\Exception\KeyNotUniqueException;
 use Sulu\Bundle\CategoryBundle\Entity\Category as CategoryEntity;
@@ -300,10 +301,8 @@ class CategoryManager implements CategoryManagerInterface
             } else {
                 return $this->createCategory($data, $this->getUser($userId));
             }
-        } catch (\Doctrine\DBAL\DBALException $e) {
-            // FIXME: This hides any exceptions thrown by DBAL.
-            //        See https://github.com/sulu-cmf/sulu/issues/871
-            throw new KeyNotUniqueException();
+        } catch (UniqueConstraintViolationException $e) {
+            throw new KeyNotUniqueException($data['key'], $e);
         }
     }
 

--- a/src/Sulu/Bundle/CategoryBundle/Category/Exception/KeyNotUniqueException.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/Exception/KeyNotUniqueException.php
@@ -15,11 +15,15 @@ use Sulu\Component\Rest\Exception\RestException;
 
 class KeyNotUniqueException extends RestException
 {
-    public function toArray()
+    /**
+     * @var string
+     */
+    private $key;
+
+    public function __construct($key, \Exception $previous)
     {
-        return [
-            'code' => 1,
-            'message' => 'A category-key has to be unique',
-        ];
+        parent::__construct('A category-key has to be unique or null', 1, $previous);
+
+        $this->key = $key;
     }
 }

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
@@ -10,7 +10,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="key" column="category_key" type="string" length="45" nullable="true" unique="true"/>
+        <field name="key" column="category_key" type="string" length="255" nullable="true" unique="true"/>
         <field name="defaultLocale" column="default_locale" type="string" length="5" nullable="false"/>
 
         <field name="lft" type="integer" column="lft">

--- a/src/Sulu/Bundle/CategoryBundle/Resources/views/Template/category.form.details.html.twig
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/views/Template/category.form.details.html.twig
@@ -10,7 +10,8 @@
             <label for="change-key"><%= translate('public.key') %></label>
             <input class="form-element" type="text" id="change-key" placeholder="<%= translate('sulu.category.category-key') %>"
                    data-validation-required="false"
-                   data-mapper-property="key"/>
+                   data-mapper-property="key"
+                   data-validation-max-length="255"/>
         </div>
     </div>
 </form>

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -107,6 +107,7 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
      * @param AccountAddressEntity $accountAddress
      *
      * @throws \Exception
+     *
      * @return mixed|void
      */
     public function removeAddressRelation($account, $accountAddress)

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\ContactBundle\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
 use Doctrine\Common\Persistence\ObjectManager;
 use FOS\RestBundle\Routing\ClassResourceInterface;
 use Hateoas\Representation\CollectionRepresentation;
@@ -33,6 +32,7 @@ use Sulu\Component\Rest\ListBuilder\ListRepresentation;
 use Sulu\Component\Rest\RestController;
 use Sulu\Component\Rest\RestHelperInterface;
 use Sulu\Component\Security\SecuredControllerInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Makes accounts available through a REST API.

--- a/src/Sulu/Bundle/ContactBundle/Controller/CountryController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/CountryController.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * This file is part of the Sulu.
+ * This file is part of Sulu.
  *
  * (c) MASSIVE ART WebServices GmbH
  *

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Sitemap/SitemapXMLGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Sitemap/SitemapXMLGeneratorTest.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * This file is part of the Sulu.
+ * This file is part of Sulu.
  *
  * (c) MASSIVE ART WebServices GmbH
  *

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -203,7 +203,7 @@ class SeoTwigExtension extends \Twig_Extension
                 }
 
                 $html .= $this->renderAlternateLink($url, $webspaceKey, $locale, false, $scheme);
-                $concreteTranslations++;
+                ++$concreteTranslations;
             }
         }
 

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -237,7 +237,6 @@ class ContentRepository implements ContentRepositoryInterface
         return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $webspaceKey, $mapping, $user);
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
@@ -212,8 +212,8 @@ class FieldDescriptorFactoryTest extends \PHPUnit_Framework_TestCase
                         'field-name' => 'SuluContactBundle:Contact.contactAddresses',
                         'method' => 'LEFT',
                         'condition' => 'SuluContactBundle:ContactAddress.locale = \'de\'',
-                    ]
-                ]
+                    ],
+                ],
             ],
         ];
 

--- a/src/Sulu/Component/Util/ArrayUtils.php
+++ b/src/Sulu/Component/Util/ArrayUtils.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * This file is part of the Sulu.
+ * This file is part of Sulu.
  *
  * (c) MASSIVE ART WebServices GmbH
  *
@@ -22,7 +23,7 @@ final class ArrayUtils
     }
 
     /**
-     * Filter array with given symfony-expression
+     * Filter array with given symfony-expression.
      *
      * @param array $collection
      * @param string $expression

--- a/src/Sulu/Component/Util/Tests/Unit/ArrayUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/ArrayUtilsTest.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * This file is part of the Sulu.
+ * This file is part of Sulu.
  *
  * (c) MASSIVE ART WebServices GmbH
  *


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #871 and fixes #2040 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The category key is limited to the length of 45 characters without any reason. This PR extend this to 255 and add the validation in the frontend. Additionally it fixes a bug with catching and hiding all doctrine exceptions when saving a category.