### PR TITLE
Fixed translation code length in database schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2097 [TranslateBundle]     Fixed translation code length in database schema
     * ENHANCEMENT #2082 [All]                 Get rid of the aliased evenement composer constraint
     * ENHANCEMENT #2035 [ContentBundle]       Add structure type to index
     * BUGFIX      #2058 [ListBuilder]         Fixed cache for field-descriptor

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,16 @@
 
 ## dev-develop
 
+### Translation Code
+
+The maximum length of the translation code was extended run the following
+command to update your database schema.
+
+```bash
+app/console doctrine:schema:update --force
+```
+
+
 ### Definition of security contexts
 
 The definition of security contexts in the `Admin` classes has changed. They

--- a/src/Sulu/Bundle/TranslateBundle/Resources/config/doctrine/Code.orm.xml
+++ b/src/Sulu/Bundle/TranslateBundle/Resources/config/doctrine/Code.orm.xml
@@ -4,7 +4,7 @@
     <id name="id" type="integer" column="id">
       <generator strategy="IDENTITY"/>
     </id>
-    <field name="code" type="string" column="code" length="60"/>
+    <field name="code" type="string" column="code" length="255"/>
     <field name="backend" type="boolean" column="backend"/>
     <field name="frontend" type="boolean" column="frontend"/>
     <field name="length" type="integer" column="length" nullable="true"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes (see UPGRADE)
| Deprecations? | no
| Fixed tickets | fixes #1997 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR extend the maximum length of translation codes.