### PR TITLE
(rel: #2037) Document context event subscribers

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/SubscriberPass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/SubscriberPass.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Compiler pass to register document manager subscribers.
+ *
+ * Subscriber tags may indicate to which document manager they
+ * should be associated.
+ */
+class SubscriberPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $managers = $container->getParameter('sulu_document_manager.managers');
+        $baseDispatcherId = 'sulu_document_manager.event_dispatcher';
+        $dispatcherIds = [];
+
+        foreach ($managers as $inde => $manager) {
+            $dispatcherId = $baseDispatcherId . '.' . $manager;
+
+            // TODO: Why would this happen?
+            if (!$container->hasDefinition($dispatcherId) && !$container->hasAlias($dispatcherId)) {
+                continue;
+            }
+
+            $dispatcherIds[] = $dispatcherId;
+        }
+
+        foreach ($container->findTaggedServiceIds('sulu_document_manager.event_subscriber') as $subscriberId => $attributes) {
+            $subscriber = $container->getDefinition($subscriberId);
+
+            if (!$subscriber->isPublic()) {
+                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as event subscribers are lazy-loaded.', $subscriberId));
+            }
+
+            if ($subscriber->isAbstract()) {
+                throw new \InvalidArgumentException(sprintf('The service "%s" must not be abstract as event subscribers are lazy-loaded.', $subscriberId));
+            }
+
+            // We must assume that the class value has been correctly filled, even if the service is created by a factory
+            $class = $container->getParameterBag()->resolveValue($subscriber->getClass());
+
+            $reflClass = new \ReflectionClass($class);
+            $interface = 'Symfony\Component\EventDispatcher\EventSubscriberInterface';
+
+            if (!$reflClass->implementsInterface($interface)) {
+                throw new \InvalidArgumentException(sprintf('Service "%s" must implement interface "%s".', $subscriberId, $interface));
+            }
+
+            $validKeys = ['manager'];
+
+            // throw a good exception if the specified manager does not exist.
+            if ($diff = array_diff(array_keys($attributes[0]), $validKeys)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Subscriber "%s" has invalid tag keys: "%s", valid keys: "%s"',
+                    $subscriberId,
+                    implode('", "', $diff),
+                    implode('", "', $validKeys)
+                ));
+            }
+
+            // build the list of event dispatcher IDs to which this subscriber should be added.
+            // note that the "manager" attribute may be a comma-separated list of manager names.
+            $targetDispatcherIds = [];
+            if (isset($attributes[0]['manager'])) {
+                $targetDispatcherIds = [];
+                $documentManagerNames = array_unique(explode(',', $attributes[0]['manager']));
+
+                foreach ($documentManagerNames as $documentManagerName) {
+                    if (!in_array($documentManagerName, $managers)) {
+                        throw new \InvalidArgumentException(sprintf(
+                            'Unknown document manager "%s" specified for event subscriber "%s". Known document managers: "%s"',
+                            $documentManagerName, $subscriberId, implode('", "', $managers)
+                        ));
+                    }
+
+                    $dispatcherId = $baseDispatcherId . '.' . $documentManagerName;
+                    $targetDispatcherIds[] = $dispatcherId;
+                }
+            } else {
+                $targetDispatcherIds = $dispatcherIds;
+            }
+
+            foreach ($targetDispatcherIds as $dispatcherId) {
+                $dispatcher = $container->findDefinition($dispatcherId);
+                $dispatcher->addMethodCall('addSubscriberService', [$subscriberId, $class]);
+            }
+        }
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -61,43 +61,61 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
         $loader->load('core.xml');
-        $this->configureDocumentManager($config, $container);
-        $this->loadDocumentManagers($config, $container);
         $loader->load('behaviors.xml');
         $loader->load('serializer.xml');
         $loader->load('command.xml');
         $loader->load('data_fixtures.xml');
+        $this->configureDocumentManagers($config, $container);
     }
 
-    private function loadDocumentManagers(array $config, ContainerBuilder $container)
+    private function configureDocumentManagers(array $config, ContainerBuilder $container)
     {
+        // set the default document manager
         $defaultManager = $config['default_manager'];
         $container->setParameter('sulu_document_manager.default_manager', $defaultManager);
 
-        $managerMap = [];
+        // let the container know what the manager names are (required for
+        // example in the SubscriberPass).
+        $container->setParameter('sulu_document_manager.managers', array_keys($config['managers']));
 
+        // create the document manager services.
+        $managerMap = [];
+        $debug = $config['debug'];
         foreach ($config['managers'] as $name => $manager) {
+            // create a concrete event dispatcher for the document manager from
+            // the abstract service.  choose either the debug or "standard"
+            // dispatcher based on the "debug" flag.
+            $abstractDispatcherId = $debug ? 'sulu_document_manager.abstract_event_dispatcher.debug' : 'sulu_document_manager.abstract_event_dispatcher.standard';
+            $dispatcherId = sprintf('sulu_document_manager.event_dispatcher.%s', $name);
+            $dispatcherDef = new DefinitionDecorator($abstractDispatcherId);
+            $dispatcherDef->setPublic(false);
+            $container->setDefinition($dispatcherId, $dispatcherDef);
+
+            // create the concrete document manager instance from the abstract
+            // service using the correct PHPCR session and the event dispatcher
+            // defined above.
             $phpcrSessionId = sprintf('doctrine_phpcr.%s_session', $manager['session']);
             $managerId = sprintf('sulu_document_manager.document_manager.%s', $name);
             $managerDef = new DefinitionDecorator('sulu_document_manager.abstract_document_manager');
             $managerDef->replaceArgument(0, new Reference($phpcrSessionId));
+            $managerDef->replaceArgument(1, new Reference($dispatcherId));
             $container->setDefinition($managerId, $managerDef);
             $managerMap[$name] = $managerId;
         }
 
+        // set the document manager service map on the document manager registry.
         $registryDef = $container->getDefinition('sulu_document_manager.registry');
         $registryDef->replaceArgument(1, $managerMap);
 
+        // create aliases to the default services.
         $container->setAlias('sulu_document_manager.document_manager', 'sulu_document_manager.document_manager.' . $defaultManager);
-    }
+        $container->setAlias('sulu_document_manager.event_dispatcher', 'sulu_document_manager.event_dispatcher.' . $defaultManager);
 
-    private function configureDocumentManager($config, ContainerBuilder $container)
-    {
-        $debug = $config['debug'];
-
-        $dispatcherId = $debug ? 'sulu_document_manager.event_dispatcher.debug' : 'sulu_document_manager.event_dispatcher.standard';
-        $container->setAlias('sulu_document_manager.event_dispatcher', $dispatcherId);
-
+        // set the metadata mapping configuration into the container (it is then
+        // subsequently used by the MetadataSubscriber).
+        //
+        // NOTE: It would potentially be cleaner to directly set these configuration
+        //       values on the service definition(s) themselves.
         $realMapping = [];
         foreach ($config['mapping'] as $alias => $mapping) {
             $realMapping[] = array_merge([

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -5,14 +5,14 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- Core -->
-        <service id="sulu_document_manager.event_dispatcher.debug" class="Sulu\Component\DocumentManager\EventDispatcher\DebugEventDispatcher" public="false">
+        <service id="sulu_document_manager.abstract_event_dispatcher.debug" class="Sulu\Component\DocumentManager\EventDispatcher\DebugEventDispatcher" abstract="true">
             <argument type="service" id="service_container" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" />
             <tag name="monolog.logger" channel="sulu_document_manager" />
         </service>
 
-        <service id="sulu_document_manager.event_dispatcher.standard" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher" public="false">
+        <service id="sulu_document_manager.abstract_event_dispatcher.standard" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher" abstract="true">
             <argument type="service" id="service_container" />
         </service>
 
@@ -23,8 +23,8 @@
         </service>
 
         <service id="sulu_document_manager.abstract_document_manager" class="Sulu\Component\DocumentManager\DocumentManager" abstract="true">
-            <argument />
-            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <argument /> <!-- the PHPCR session -->
+            <argument /> <!-- the event dispatcher -->
             <argument type="service" id="sulu_document_manager.metadata_factory"/>
             <argument type="service" id="sulu_document_manager.proxy_manager.factory.ghost"/>
             <argument type="service" id="sulu_document_manager.document_inspector_factory" />

--- a/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
@@ -12,8 +12,8 @@
 namespace Sulu\Bundle\DocumentManagerBundle;
 
 use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\InitializerPass;
+use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\SubscriberPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SuluDocumentManagerBundle extends Bundle
@@ -22,10 +22,6 @@ class SuluDocumentManagerBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new InitializerPass());
-        $container->addCompilerPass(new RegisterListenersPass(
-            'sulu_document_manager.event_dispatcher',
-            'sulu_document_manager.event_listener',
-            'sulu_document_manager.event_subscriber'
-        ));
+        $container->addCompilerPass(new SubscriberPass());
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DependencyInjection/Compiler/SubscriberPassTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DependencyInjection/Compiler/SubscriberPassTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\SubscriberPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SubscriberPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EventSubscriberInterface
+     */
+    private $subscriber1;
+
+    /**
+     * @var EventSubscriberInterface
+     */
+    private $subscriber2;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher1;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher2;
+
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var SubscriberPass
+     */
+    private $pass;
+
+    public function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->subscriber1 = $this->prophesize(EventSubscriberInterface::class);
+        $this->subscriber2 = $this->prophesize(EventSubscriberInterface::class);
+
+        $this->dispatcher1 = $this->container->register('sulu_document_manager.event_dispatcher.default', EventDispatcherInterface::class);
+        $this->dispatcher2 = $this->container->register('sulu_document_manager.event_dispatcher.prod', EventDispatcherInterface::class);
+        $this->pass = new SubscriberPass();
+        $this->container->setParameter('sulu_document_manager.managers', ['default', 'prod']);
+    }
+
+    /**
+     * It should throw an exception if the subscriber is not public.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The service "subscriber_1" must be public as event subscribers are lazy-loaded
+     */
+    public function testDispatcherNotPublic()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default']);
+        $subscriberDef1->setPublic(false);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should throw an exception if the subscriber is abstract.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The service "subscriber_1" must not be abstract as event subscribers are lazy-loaded.
+     */
+    public function testDispatcherAbstract()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default']);
+        $subscriberDef1->setAbstract(true);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should throw an exception if the subscriber does not implement the event subscriber interface.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Service "subscriber_1" must implement interface "Symfony\Component\EventDispatcher\EventSubscriberInterface"
+     */
+    public function testDispatcherNotImplementing()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', 'stdClass');
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default']);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should throw an exception if the event subscriber specifies a non-existant manager.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown document manager "not-existing" specified for event subscriber "subscriber_1". Known document managers: "default", "prod"
+     */
+    public function testNonExistingManager()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'not-existing']);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should throw an exception if the tag has invalid keys.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Subscriber "subscriber_1" has invalid tag keys: "bar", valid keys: "manager"
+     */
+    public function testInvalidKeys()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['bar' => 'foo']);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should add subscribers to specific event dispatchers.
+     */
+    public function testSpecificDispatchers()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default']);
+
+        $subscriberDef2 = $this->container->register('subscriber_2', get_class($this->subscriber2->reveal()));
+        $subscriberDef2->addTag('sulu_document_manager.event_subscriber', ['manager' => 'prod']);
+
+        $this->pass->process($this->container);
+
+        $calls = $this->dispatcher1->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+
+        $calls = $this->dispatcher2->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_2',
+                get_class($this->subscriber2->reveal()),
+            ],
+        ]);
+    }
+
+    /**
+     * It should allow a comma-separated list of managers.
+     */
+    public function testSpecificDispatchersCommaSeparated()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default,prod']);
+
+        $this->pass->process($this->container);
+
+        $calls = $this->dispatcher1->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+
+        $calls = $this->dispatcher2->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+    }
+
+    /**
+     * It should add to all managers if no manager is specified.
+     */
+    public function testAllManagers()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber');
+
+        $subscriberDef2 = $this->container->register('subscriber_2', get_class($this->subscriber2->reveal()));
+        $subscriberDef2->addTag('sulu_document_manager.event_subscriber');
+
+        $this->pass->process($this->container);
+
+        $calls = $this->dispatcher1->getMethodCalls();
+
+        $this->assertCount(2, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+        $this->assertEquals($calls[1], [
+            'addSubscriberService',
+            [
+                'subscriber_2',
+                get_class($this->subscriber2->reveal()),
+            ],
+        ]);
+
+        $calls = $this->dispatcher2->getMethodCalls();
+
+        $this->assertCount(2, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to add event subscribers to speciific document manager dispatchers, building on the existing #2037 PR.