### PR TITLE
[ENHANCEMENT] Added account tag filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #2102 [ContactBundle]     Added filter for account tags
+
 * 1.1.10 (2016-03-07)
     * HOTFIX      #2029 [WebsiteBundle]     Removed single alternate link in sitemap.xml
     * HOTFIX      #2029 [WebsiteBundle]     Fixed hreflang tag with one translation and different schemas

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,7 +17,11 @@ INSERT INTO `re_operator_translations` (`id`, `name`, `locale`, `shortDescriptio
     (35, 'gleich', 'de', NULL, NULL, 18),
     (36, 'is', 'en', NULL, NULL, 18),
     (37, 'ungleich', 'de', NULL, NULL, 19),
-    (38, 'is not', 'en', NULL, NULL, 19);
+    (38, 'is not', 'en', NULL, NULL, 19),
+    (39, 'und', 'de', NULL, NULL, 16),
+    (40, 'and', 'en', NULL, NULL, 16),
+    (41, 'oder', 'de', NULL, NULL, 17),
+    (42, 'or', 'en', NULL, NULL, 17);
 ```
 
 Additionally the filter by country has changed. Run following SQL script to update your filter conditions:

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/list-builder/Account.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/list-builder/Account.xml
@@ -175,5 +175,19 @@
             <orm:field-name>placeOfJurisdiction</orm:field-name>
             <orm:entity-name>%sulu_contact.account.entity%</orm:entity-name>
         </property>
+
+        <group-concat-property name="tagIds" display="never" filter-type="tags"
+                               list:translation="public.tags"
+                               orm:glue=",">
+            <orm:field-name>id</orm:field-name>
+            <orm:entity-name>SuluTagBundle:Tag</orm:entity-name>
+
+            <orm:joins>
+                <orm:join>
+                    <orm:entity-name>SuluTagBundle:Tag</orm:entity-name>
+                    <orm:field-name>%sulu_contact.account.entity%.tags</orm:field-name>
+                </orm:join>
+            </orm:joins>
+        </group-concat-property>
     </properties>
 </class>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Added filter for account tags.

#### Why?

Because this filter wasn't implemented yet. (whaaaaat?)

#### Example Usage

Go to contacts / account list and filter the list by tag(s)

#### To Do

- [ ] Hoping that this example description will ever end.
- [ ] Get this thing merged.
