### PR TITLE
Fixed portal redirect to local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2107 [WebsiteBundle]       Fixed portal redirect to local
     * BUGFIX      #2090 [MediaBundle]         Fixed fallback of media file-version meta
     * BUGFIX      #2092 [ContactBundle]       Fixed new contact when creating a new contact in the account
     * BUGFIX      #2100 [ContactBundle]       Fixed switching tab in contact and account after save

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/DefaultController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/DefaultController.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\WebsiteBundle\Controller;
 
 use Sulu\Component\Content\Compat\StructureInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -45,89 +44,41 @@ class DefaultController extends WebsiteController
 
     /**
      * Creates a redirect for configured webspaces.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     *
+     * @deprecated since 1.2 use SuluWebsiteBundle:Redirect:redirectWebspace instead
      */
     public function redirectWebspaceAction(Request $request)
     {
-        $url = $this->resolveRedirectUrl(
-            $request->get('redirect'),
-            $request->getUri()
-        );
+        @trigger_error('SuluWebsiteBundle:Default:redirectWebspace is deprecated since version 1.2. Use the "SuluWebsiteBundle:Redirect:redirectWebspace" action instead.', E_USER_DEPRECATED);
 
-        return new RedirectResponse($url, 301);
+        return $this->forward(
+            'SuluWebsiteBundle:Redirect:redirectWebspace',
+            $request->attributes->all(),
+            $request->query->all()
+        );
     }
 
     /**
      * Creates a redirect for *.html to * (without html).
+     *
+     * @param Request $request
+     *
+     * @return Response
+     *
+     * @deprecated since 1.2 use SuluWebsiteBundle:Redirect:redirect instead
      */
     public function redirectAction(Request $request)
     {
-        return new RedirectResponse($request->get('url'), 301);
-    }
+        @trigger_error('SuluWebsiteBundle:Default:redirect is deprecated since version 1.2. Use the "SuluWebsiteBundle:Redirect:redirect" action instead.', E_USER_DEPRECATED);
 
-    /**
-     * Resolve the redirect URL, appending any additional path data.
-     *
-     * @param string $redirectUrl Redirect webspace URI
-     * @param string $requestUri The actual incoming request URI
-     *
-     * @return string URL to redirect to
-     */
-    protected function resolveRedirectUrl($redirectUrl, $requestUri)
-    {
-        $redirectInfo = $this->parseUrl($redirectUrl);
-        $requestInfo = $this->parseUrl($requestUri);
-
-        $url = sprintf('%s://%s', $requestInfo['scheme'], $requestInfo['host']);
-
-        if (isset($redirectInfo['host'])) {
-            $url = sprintf('%s://%s', $requestInfo['scheme'], $redirectInfo['host']);
-        }
-
-        if (isset($requestInfo['port'])) {
-            $url .= ':' . $requestInfo['port'];
-        }
-
-        if (
-            isset($redirectInfo['path'])
-            && (
-                // if requested url not starting with redirectUrl it need to be added
-                !isset($requestInfo['path'])
-                || strpos($requestInfo['path'], $redirectInfo['path'] . '/') !== 0
-            )
-        ) {
-            $url .= $redirectInfo['path'];
-        }
-
-        if (isset($requestInfo['path'])) {
-            $url .= $requestInfo['path'];
-            $url = rtrim($url, '/');
-        }
-
-        if (isset($requestInfo['query'])) {
-            $url .= '?' . $requestInfo['query'];
-        }
-
-        if (isset($requestInfo['fragment'])) {
-            $url .= '#' . $requestInfo['fragment'];
-        }
-
-        return $url;
-    }
-
-    /**
-     * Prefix http to the URL if it is missing and
-     * then parse the string using parse_url.
-     *
-     * @param string
-     *
-     * @return string
-     */
-    private function parseUrl($url)
-    {
-        if (!preg_match('{^https?://}', $url)) {
-            $url = 'http://' . $url;
-        }
-
-        return parse_url($url);
+        return $this->forward(
+            'SuluWebsiteBundle:Redirect:redirect',
+            $request->attributes->all(),
+            $request->query->all()
+        );
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
@@ -1,0 +1,143 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Contains redirect actions.
+ */
+class RedirectController extends Controller
+{
+    /**
+     * Creates a redirect for configured webspaces.
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function redirectWebspaceAction(Request $request)
+    {
+        $url = $this->resolveRedirectUrl(
+            $request->get('redirect'),
+            $request->getUri()
+        );
+
+        return new RedirectResponse($url, 301);
+    }
+
+    /**
+     * Creates a redirect for *.html to * (without html).
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function redirectAction(Request $request)
+    {
+        return new RedirectResponse($request->get('url'), 301);
+    }
+
+    /**
+     * Create a redirect response which uses a route to generate redirect.
+     *
+     * @param Request $request
+     * @param string $route
+     * @param bool $permanent
+     *
+     * @return RedirectResponse
+     */
+    public function redirectToRouteAction(Request $request, $route, $permanent = false)
+    {
+        if ('' === $route) {
+            throw new HttpException($permanent ? 410 : 404);
+        }
+
+        $attributes = array_merge($request->attributes->get('_route_params'), $request->query->all());
+        unset($attributes['route'], $attributes['permanent']);
+
+        return new RedirectResponse(
+            $this->container->get('router')->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL),
+            $permanent ? 301 : 302
+        );
+    }
+
+    /**
+     * Resolve the redirect URL, appending any additional path data.
+     *
+     * @param string $redirectUrl Redirect webspace URI
+     * @param string $requestUri The actual incoming request URI
+     *
+     * @return string URL to redirect to
+     */
+    private function resolveRedirectUrl($redirectUrl, $requestUri)
+    {
+        $redirectInfo = $this->parseUrl($redirectUrl);
+        $requestInfo = $this->parseUrl($requestUri);
+
+        $url = sprintf('%s://%s', $requestInfo['scheme'], $requestInfo['host']);
+
+        if (isset($redirectInfo['host'])) {
+            $url = sprintf('%s://%s', $requestInfo['scheme'], $redirectInfo['host']);
+        }
+
+        if (isset($requestInfo['port'])) {
+            $url .= ':' . $requestInfo['port'];
+        }
+
+        if (
+            isset($redirectInfo['path'])
+            && (
+                // if requested url not starting with redirectUrl it need to be added
+                !isset($requestInfo['path'])
+                || strpos($requestInfo['path'], $redirectInfo['path'] . '/') !== 0
+            )
+        ) {
+            $url .= $redirectInfo['path'];
+        }
+
+        if (isset($requestInfo['path'])) {
+            $url .= $requestInfo['path'];
+            $url = rtrim($url, '/');
+        }
+
+        if (isset($requestInfo['query'])) {
+            $url .= '?' . $requestInfo['query'];
+        }
+
+        if (isset($requestInfo['fragment'])) {
+            $url .= '#' . $requestInfo['fragment'];
+        }
+
+        return $url;
+    }
+
+    /**
+     * Prefix http to the URL if it is missing and
+     * then parse the string using parse_url.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    private function parseUrl($url)
+    {
+        if (!preg_match('{^https?://}', $url)) {
+            $url = 'http://' . $url;
+        }
+
+        return parse_url($url);
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -19,7 +19,6 @@ use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -226,7 +225,7 @@ class ContentRouteProvider implements RouteProviderInterface
         // redirect by information from webspace config
         return new Route(
             $request->getPathInfo(), [
-                '_controller' => 'SuluWebsiteBundle:Default:redirectWebspace',
+                '_controller' => 'SuluWebsiteBundle:Redirect:redirectWebspace',
                 'url' => $this->requestAnalyzer->getPortalUrl(),
                 'redirect' => $this->requestAnalyzer->getRedirect(),
             ]
@@ -244,7 +243,7 @@ class ContentRouteProvider implements RouteProviderInterface
         // redirect to linked page
         return new Route(
             $request->getPathInfo(), [
-                '_controller' => 'SuluWebsiteBundle:Default:redirect',
+                '_controller' => 'SuluWebsiteBundle:Redirect:redirect',
                 'url' => $url,
             ]
         );

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -11,8 +11,8 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Routing;
 
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
-use Sulu\Component\Webspace\Portal;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -78,6 +78,16 @@ class PortalLoader extends Loader
             $route = clone $importedRoute;
             $route->setHost($portalInformation->getHost());
             $route->setPath($portalInformation->getPrefix() . $route->getPath());
+
+            if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_PARTIAL) {
+                $route->setDefaults(
+                    [
+                        '_controller' => 'SuluWebsiteBundle:Redirect:redirectToRoute',
+                        'route' => $portalInformation->getRedirect() . '.' . $importedRouteName,
+                        'permanent' => true,
+                    ]
+                );
+            }
 
             $this->collection->add($portalInformation->getUrl() . '.' . $importedRouteName, $route);
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/RedirectControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/RedirectControllerTest.php
@@ -1,0 +1,156 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class RedirectControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RedirectController
+     */
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new RedirectController();
+    }
+
+    private function getRequestMock($requestUrl, $portalUrl, $redirectUrl = null)
+    {
+        $request = $this->getMockBuilder(Request::class)->getMock();
+        $request->expects($this->any())->method('get')->will(
+            $this->returnValueMap(
+                [
+                    ['url', null, false, $portalUrl],
+                    ['redirect', null, false, $redirectUrl],
+                ]
+            )
+        );
+        $request->expects($this->any())->method('getUri')->will($this->returnValue($requestUrl));
+
+        return $request;
+    }
+
+    public function provideRedirectAction()
+    {
+        return [
+            ['http://sulu.lo/articles?foo=bar', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo/en/articles?foo=bar'],
+            ['http://sulu.lo/articles?foo=bar&bar=boo', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo/en/articles?foo=bar&bar=boo'],
+            ['http://sulu.lo/articles/?foo=bar', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo/en/articles?foo=bar'],
+            ['http://sulu.lo/articles/?foo=bar&bar=boo', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo/en/articles?foo=bar&bar=boo'],
+            ['http://sulu.lo/en/articles/?foo=bar', 'sulu.lo', null, 'http://sulu.lo/en/articles?foo=bar'],
+            ['http://sulu.lo/en/articles/?foo=bar&bar=boo', 'sulu.lo', null, 'http://sulu.lo/en/articles?foo=bar&bar=boo'],
+            ['sulu.lo:8001/', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo:8001/en'],
+            ['sulu.lo:8001/#foobar', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo:8001/en#foobar'],
+            ['sulu.lo:8001/articles#foobar', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo:8001/en/articles#foobar'],
+            ['sulu-redirect.lo/', 'sulu-redirect.lo', 'sulu.lo', 'http://sulu.lo'],
+            ['sulu-redirect.lo/', 'sulu-redirect.lo', 'sulu.lo', 'http://sulu.lo'],
+            ['http://sulu.lo:8002/', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo:8002/en'],
+            ['http://sulu.lo/articles', 'sulu.lo/en', 'sulu.lo/de', 'http://sulu.lo/de/articles'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideRedirectAction
+     */
+    public function testRedirectAction($requestUri, $portalUrl, $redirectUrl, $expectedTargetUrl)
+    {
+        $request = $this->getRequestMock($requestUri, $portalUrl, $redirectUrl);
+
+        $response = $this->controller->redirectWebspaceAction($request);
+
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals($expectedTargetUrl, $response->getTargetUrl());
+    }
+
+    public function provideRedirectWebspaceAction()
+    {
+        return [
+            ['sulu.lo/de', 'http://sulu.lo', 'http://sulu.lo/de'],
+            ['http://sulu.lo/de', 'http://sulu.lo', 'http://sulu.lo/de'],
+            ['http://sulu.lo', 'http://sulu.lo/de/test', 'http://sulu.lo/de/test'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideRedirectWebspaceAction
+     */
+    public function testRedirectWebspaceAction($uri, $redirectUri, $expectedTargetUrl)
+    {
+        $request = $this->getRequestMock($redirectUri, null, $uri);
+
+        $response = $this->controller->redirectWebspaceAction($request);
+
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals($expectedTargetUrl, $response->getTargetUrl());
+    }
+
+    public function provideRedirectToRouteAction()
+    {
+        return [
+            ['', 410],
+            ['', 404, false],
+            ['test'],
+            ['test', 302, false],
+            ['test', 302, false, ['test' => 1]],
+            ['test', 301, true, ['test' => 1]],
+            ['test', 302, false, [], ['test' => 1]],
+            ['test', 301, true, [], ['test' => 1]],
+            ['test', 302, false, ['test-1' => 1], ['test-2' => 1]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideRedirectToRouteAction
+     */
+    public function testRedirectToRouteAction(
+        $route,
+        $statusCode = 301,
+        $permanent = true,
+        $attributesData = [],
+        $queryData = []
+    ) {
+        if ($statusCode >= 400) {
+            $this->setExpectedException(HttpException::class);
+        }
+
+        $attributes = $this->prophesize(ParameterBag::class);
+        $attributes->get('_route_params')->willReturn(
+            array_merge($attributesData, ['route' => $route, 'permanent' => $permanent])
+        );
+
+        $query = $this->prophesize(ParameterBag::class);
+        $query->all()->willReturn($queryData);
+
+        $router = $this->prophesize(RouterInterface::class);
+        $router->generate($route, array_merge($attributesData, $queryData), UrlGeneratorInterface::ABSOLUTE_URL)->willReturn('/test-route');
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('router')->willReturn($router->reveal());
+
+        $request = $this->prophesize(Request::class);
+        $request->reveal()->attributes = $attributes->reveal();
+        $request->reveal()->query = $query->reveal();
+
+        $this->controller->setContainer($container->reveal());
+
+        $response = $this->controller->redirectToRouteAction($request->reveal(), $route, $permanent);
+
+        $this->assertEquals($statusCode, $response->getStatusCode());
+        $this->assertEquals('/test-route', $response->getTargetUrl());
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -164,7 +164,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('SuluWebsiteBundle:Default:redirectWebspace', $route->getDefaults()['_controller']);
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirectWebspace', $route->getDefaults()['_controller']);
         $this->assertEquals('sulu.lo/de/', $route->getDefaults()['url']);
         $this->assertEquals('sulu.lo/de', $route->getDefaults()['redirect']);
     }
@@ -241,7 +241,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('SuluWebsiteBundle:Default:redirectWebspace', $route->getDefaults()['_controller']);
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirectWebspace', $route->getDefaults()['_controller']);
         $this->assertEquals('sulu.lo', $route->getDefaults()['url']);
         $this->assertEquals('sulu.lo/en-us', $route->getDefaults()['redirect']);
     }
@@ -319,7 +319,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('SuluWebsiteBundle:Default:redirectWebspace', $route->getDefaults()['_controller']);
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirectWebspace', $route->getDefaults()['_controller']);
         $this->assertEquals('sulu-redirect.lo', $route->getDefaults()['url']);
         $this->assertEquals('sulu.lo', $route->getDefaults()['redirect']);
     }
@@ -367,7 +367,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('SuluWebsiteBundle:Default:redirect', $route->getDefaults()['_controller']);
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirect', $route->getDefaults()['_controller']);
         $this->assertEquals('/de/other-test', $route->getDefaults()['url']);
     }
 
@@ -414,7 +414,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('SuluWebsiteBundle:Default:redirect', $route->getDefaults()['_controller']);
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirect', $route->getDefaults()['_controller']);
         $this->assertEquals('http://www.example.org', $route->getDefaults()['url']);
     }
 
@@ -458,7 +458,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('SuluWebsiteBundle:Default:redirectWebspace', $route->getDefaults()['_controller']);
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirectWebspace', $route->getDefaults()['_controller']);
         $this->assertEquals('sulu.lo', $route->getDefaults()['url']);
     }
 
@@ -502,7 +502,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('SuluWebsiteBundle:Default:redirectWebspace', $route->getDefaults()['_controller']);
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirectWebspace', $route->getDefaults()['_controller']);
         $this->assertEquals('sulu.lo', $route->getDefaults()['url']);
     }
 
@@ -548,7 +548,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('SuluWebsiteBundle:Default:redirect', $route->getDefaults()['_controller']);
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirect', $route->getDefaults()['_controller']);
         $this->assertEquals('/de/new-test', $route->getDefaults()['url']);
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\WebsiteBundle\Routing;
 
 use Prophecy\Argument;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
@@ -89,5 +90,49 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/de/route2', $routeCollection->get('sulu.io/de.route2')->getPath());
         $this->assertEquals('/example/route1', $routeCollection->get('sulu.com.route1')->getPath());
         $this->assertEquals('/route2', $routeCollection->get('sulu.com.route2')->getPath());
+    }
+
+    public function testLoadPartial()
+    {
+        $importedRouteCollection = new RouteCollection();
+        $importedRouteCollection->add('route', new Route('/route'));
+
+        $portal = new Portal();
+        $portal->setKey('sulu_lo');
+
+        $portalInformations = [
+            new PortalInformation(null, null, $portal, null, 'sulu.io/de'),
+            new PortalInformation(
+                RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
+                null,
+                $portal,
+                null,
+                'sulu.io',
+                null,
+                'sulu.io/de'
+            ),
+        ];
+
+        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
+        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+        $this->webspaceManager->getPortalInformations(Argument::any())->willReturn($portalInformations);
+
+        $routeCollection = $this->portalLoader->load('', 'portal');
+
+        $this->assertCount(2, $routeCollection);
+
+        $routes = $routeCollection->getIterator();
+        $this->assertArrayHasKey('sulu.io.route', $routes);
+        $this->assertArrayHasKey('sulu.io/de.route', $routes);
+        $this->assertEquals('/route', $routeCollection->get('sulu.io.route')->getPath());
+        $this->assertEquals('/de/route', $routeCollection->get('sulu.io/de.route')->getPath());
+        $this->assertEquals(
+            [
+                '_controller' => 'SuluWebsiteBundle:Redirect:redirectToRoute',
+                'route' => 'sulu.io/de.route',
+                'permanent' => true,
+            ],
+            $routeCollection->get('sulu.io.route')->getDefaults()
+        );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #1946 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the `PortalRouteLoader` to generate redirects for partial matched Portals. If you register your custom-routes they will be generated for each Portal.

For example the website_search in the sulu-standard:

```yml
website_search:
    pattern: /search
    defaults:
        _controller: "ClientWebsiteBundle:Search:query"
```

Generates routes for `sulu.lo/de/search` and `sulu.lo/en/search` and also for `sulu.lo/search`. The last should redirect to /en/search (en is the default locale) because sulu-pages has the same behaviour.

#### BC Breaks/Deprecations

In this PR i have deprecated the functions: 

* SuluWebsiteBundle:Default:redirect
* SuluWebsiteBundle:Default:redirectWebspaceAction

They still exists and sitll working because they forward to the new Controller `SuluWebsiteBundle:Redirect` which contains now all the redirect functions for sulu.
