### PR TITLE
Toggled the flags in the PR template from "yes" to "no"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 | Q | A
 | --- | ---
-| Bug fix? | yes
-| New feature? | yes
-| BC breaks? | yes
-| Deprecations? | yes
+| Bug fix? | no
+| New feature? | no
+| BC breaks? | no
+| Deprecations? | no
 | Fixed tickets | fixes #issuenum
 | Related issues/PRs | #issuenum
 | License | MIT


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR toggles the default values of the flags in the PR table of the PR template from "yes" to "no".

#### Why?

Most PRs require most of these flags to be set to "no". The current template requires 3-4 extra interactions for each PR:

~~~
| Bug fix? | yes
| New feature? | yes
| BC breaks? | yes
| Deprecations? | yes
~~~

Most of these have to be replaced by "no" most of the time. While the original idea was to make the creator of the PR *think* about this, I think that this quickly becomes repetitive and thus doesn't fulfill its purpose.