### PR TITLE
Update ffmpeg bundle and lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2114 [All]                 Update ffmpeg bundle and lib
     * ENHANCEMENT #2116 [All]                 Made restart of jackrabbit between tests configureable
     * BUGFIX      #2090 [MediaBundle]         Fixed fallback of media file-version meta
     * BUGFIX      #2092 [ContactBundle]       Fixed new contact when creating a new contact in the account

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "willdurand/hateoas-bundle": "0.3.*",
         "symfony/swiftmailer-bundle": "~2.3",
         "pagerfanta/pagerfanta": "~1.0",
-        "pulse00/ffmpeg-bundle": "^0.5.2",
+        "pulse00/ffmpeg-bundle": "^0.6",
         "oro/doctrine-extensions": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no, improvement
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Updates the `pulse00/ffmpeg-bundle` and thus the `php-ffmpeg/php-ffmpeg` lib. Both packages contain only fixes and no BC breaks.

#### Why?

Symfony 3.0 compatibility. Can be merged already, independent of all other PRs coming.