### PR TITLE
added option to restart jackrabbit in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - ./bin/jackrabbit.sh
 
 script: 
-  - time ./bin/runtests.sh -i -a
+  - time ./bin/runtests.sh -i -a -r
   - phpunit
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2116 [All]                 Made restart of jackrabbit between tests configureable
     * BUGFIX      #2090 [MediaBundle]         Fixed fallback of media file-version meta
     * BUGFIX      #2092 [ContactBundle]       Fixed new contact when creating a new contact in the account
     * BUGFIX      #2100 [ContactBundle]       Fixed switching tab in contact and account after save


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu-io/sulu/pull/2116

#### What's in this PR?

This content introduces a flag for restarting jackrabbit between bundle tests.

#### Why?

We need the restarts between the bundles for avoiding flaky tests. But on the local machine it is very annoying when executing the tests. So a flag seems like the best solution.

#### Example Usage

~~~bash
bin/runtests.sh -i -a # execute all tests with restarting jackrabbit
bin/runtests.sh -i -a -r # execute all testes without restarting jackrabbit
~~~