### PR TITLE
Cache composer cache dir and prefer dist downloads on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ php:
   - 5.5
   - 7.0
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 env:
   global:
     - SYMFONY_DEPRECATIONS_HELPER=weak
@@ -17,7 +21,7 @@ env:
 
 before_script:
   - composer self-update
-  - composer install
+  - composer install  --prefer-dist --no-interaction
   - ./bin/jackrabbit.sh
 
 script: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2121 [All]                 Cache composer cache dir and prefer dist downloads on Travis
     * ENHANCEMENT #2114 [All]                 Update ffmpeg bundle and lib
     * ENHANCEMENT #2116 [All]                 Made restart of jackrabbit between tests configureable
     * BUGFIX      #2090 [MediaBundle]         Fixed fallback of media file-version meta


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no, improvement
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

It sets composer cache dir to be cached by travis, thus subsequent builds install composer dependencies from cache instead downloading it every time. As a consequence `--prefer-dist` is added, because only dist packages are cached by composer.

#### Why?

To improve the speed of the Travis builds. Composer has only a minor impact, but it does not harm to utilize the Travis caches.

#### Pitfalls

Travis creates separate caches for every matrix line. Also a separate cache is created for every branch (an on push test). Pull requests with the same target share the same cache.
