### PR TITLE
Disable xdebug on Travis to speed up composer and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 #    - SULU_ORM=postgres SULU_PHPCR=doctrine_dbal
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - composer install  --prefer-dist --no-interaction
   - ./bin/jackrabbit.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2122 [All]                 Disable xdebug on Travis to speed up composer and tests
     * ENHANCEMENT #2120 [All]                 Change bundle tests to use their own phpunit config and move `SYMFONY_DEPRECATIONS_HELPER` var into
     * ENHANCEMENT #2121 [All]                 Cache composer cache dir and prefer dist downloads on Travis
     * ENHANCEMENT #2114 [All]                 Update ffmpeg bundle and lib


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no, improvement
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

It disables xdebug on Travis. As long as code-coverage is not needed, xdebug has a major performance impact. It improves over all build time about 30% or about 15-25 minutes in absolutes. Heavily depends on the performance of the workers. Build time of Sulu is relatively volatile.

#### Why?

Short build times are necessary to give quicker feedback to outside collaborators. Although one should test on his work machine, for example I execute only the test runner on the affected bundle which I change. Even If I activate Travis on my fork (see https://travis-ci.org/Karisch/sulu/builds/115661561 for example), then it's important to get faster feedback too on all builds. And quicker build times on pull requests are good for feedback to the mergers :)
