### PR TITLE
Use admin connection to initialize the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2190 [WebsiteBundle]       Fixed wrong translator locale by decorating translator
+    * ENHANCEMENT #2125 [All]                 Upgraded to DoctrinePHPCRBundle 1.3
     * BUGFIX      #2183 [ContentBundle]       Added missing locale for loading route document
     * BUGFIX      #2185 [MediaBundle]         Fixed throw exception if new version has a different media type
     * ENHANCEMENT #2182 [ContactBundle]       Added `sulu_resolve_contact` twig function

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^5.5 || ^7.0",
         "cboden/ratchet": "0.3.*",
         "doctrine/orm": "2.5.*",
-        "doctrine/phpcr-bundle": "~1.2.0",
+        "doctrine/phpcr-bundle": "~1.3.0",
         "doctrine/phpcr-odm": "~1.3.0",
         "friendsofsymfony/http-cache": "1.3.*",
         "friendsofsymfony/rest-bundle": "~1.4",

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -42,12 +42,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         if (isset($config['phpcr'])) {
             $phpcrConfig = $config['phpcr'];
 
-            // TODO: Workaround for issue: https://github.com/doctrine/DoctrinePHPCRBundle/issues/178
-            if (!isset($phpcrConfig['backend']['check_login_on_server'])) {
-                $phpcrConfig['backend']['check_login_on_server'] = false;
-            }
-
-            foreach ($container->getExtensions() as $name => $extension) {
+            foreach (array_keys($container->getExtensions()) as $name) {
                 $prependConfig = [];
                 switch ($name) {
                     case 'doctrine_phpcr':

--- a/src/Sulu/Bundle/DocumentManagerBundle/Initializer/RootPathPurger.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Initializer/RootPathPurger.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\DocumentManagerBundle\Initializer;
 
 use Doctrine\Common\Persistence\ConnectionRegistry;
+use PHPCR\RepositoryException;
 use PHPCR\SessionInterface;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;
 
@@ -51,6 +52,15 @@ class RootPathPurger implements PurgerInterface
         $rootPath = '/' . $this->pathSegments->getPathSegment($this->rootRole);
 
         foreach ($sessions as $session) {
+            try {
+                $session->getRootNode();
+            } catch (RepositoryException $e) {
+                // TODO: We should catch the more explicit
+                // WorkspaceNotFoundException but Jackalope doctrine-dbal does
+                // not throw this: https://github.com/jackalope/jackalope-doctrine-dbal/issues/322
+                continue;
+            }
+
             if ($session->nodeExists($rootPath)) {
                 $session->getNode($rootPath)->remove();
                 $session->save();

--- a/src/Sulu/Bundle/DocumentManagerBundle/Initializer/WorkspaceInitializer.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Initializer/WorkspaceInitializer.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\DocumentManagerBundle\Initializer;
 
 use Doctrine\Common\Persistence\ConnectionRegistry;
-use PHPCR\NoSuchWorkspaceException;
+use PHPCR\RepositoryException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -36,12 +36,14 @@ class WorkspaceInitializer implements InitializerInterface
     public function initialize(OutputInterface $output)
     {
         foreach ($this->registry->getConnections() as $connection) {
-            $workspace = $connection->getWorkspace();
-
             try {
                 $connection->getRootNode();
                 $output->writeln(sprintf('  [ ] <info>workspace</info>: "%s"', $workspace->getName()));
-            } catch (NoSuchWorkspaceException $e) {
+            } catch (RepositoryException $e) {
+                // TODO: We should catch the more explicit
+                // WorkspaceNotFoundException but Jackalope doctrine-dbal does
+                // not throw this: https://github.com/jackalope/jackalope-doctrine-dbal/issues/322
+                $workspace = $connection->getWorkspace();
                 $workspace->createWorkspace($workspace->getName());
                 $output->writeln(sprintf('  [+] <info>workspace</info>: "%s"', $workspace->getName()));
             }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Initialalizer;
+
+use Doctrine\Common\Persistence\ConnectionRegistry;
+use PHPCR\RepositoryException;
+use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
+use Sulu\Bundle\DocumentManagerBundle\Initializer\WorkspaceInitializer;
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class WorkspaceInitializerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session1;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session2;
+
+    /**
+     * @var ConnectionRegistry
+     */
+    private $connectionRegistry;
+
+    /**
+     * @var PathSegmentRegistry
+     */
+    private $segmentRegistry;
+
+    /**
+     * @var WorkspaceInitializer
+     */
+    private $initializer;
+
+    /**
+     * @var WorkspaceInterface
+     */
+    private $workspace;
+
+    public function setUp()
+    {
+        $this->session1 = $this->prophesize(SessionInterface::class);
+        $this->session2 = $this->prophesize(SessionInterface::class);
+        $this->connectionRegistry = $this->prophesize(ConnectionRegistry::class);
+        $this->workspace = $this->prophesize(WorkspaceInterface::class);
+        $this->output = new BufferedOutput();
+
+        $this->initializer = new WorkspaceInitializer(
+            $this->connectionRegistry->reveal()
+        );
+    }
+
+    /**
+     * It should create the workspace on connections with non-existing workspaces.
+     * It should skip connections with existing workspaces.
+     */
+    public function testCreateWorkspace()
+    {
+        $this->connectionRegistry->getConnections()->willReturn([
+            $this->session1->reveal(),
+            $this->session2->reveal(),
+        ]);
+
+        $this->session1->getRootNode()->willThrow(new RepositoryException('Foo'));
+        $this->session2->getRootNode()->willReturn(true);
+
+        $this->session1->getWorkspace()->willReturn($this->workspace->reveal());
+        $this->session2->getWorkspace()->shouldNotBeCalled();
+        $this->workspace->getName()->willReturn('hello');
+        $this->workspace->createWorkspace('hello')->shouldBeCalled();
+
+        $this->initializer->initialize($this->output);
+    }
+}

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -124,7 +124,6 @@ sulu_test:
 
 sulu_document_manager:
     debug: false
-
     mapping:
         page:
             class: Sulu\Bundle\ContentBundle\Document\PageDocument


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2013 
| License | MIT

#### What's in this PR?

This PR will remove the `check_login_on_server` check which avoids Jackalope logging into the server before workspace has been created.

#### Why?

When the DoctrinePHPCRBundle tries to login by default before doing anything, which makes causes a problem when needing to create the `default` workspace, as we cannot login if it does not exist.

The 1.3 version of the PHPCRBundle introduced the "admin" connection which can be used for such purposes.

#### To Do

- [x] Finish this


