### PR TITLE
Excluded recursion from accounts REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2126 [ContactBundle]       Excluded recursion in accounts REST API
     * ENHANCEMENT #2122 [All]                 Disable xdebug on Travis to speed up composer and tests
     * ENHANCEMENT #2120 [All]                 Change bundle tests to use their own phpunit config and move `SYMFONY_DEPRECATIONS_HELPER` var into
     * ENHANCEMENT #2121 [All]                 Cache composer cache dir and prefer dist downloads on Travis

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -389,6 +389,10 @@ class AccountController extends RestController implements ClassResourceInterface
             $view = $this->view($list, 200);
         }
 
+        $view->setSerializationContext(
+            SerializationContext::create()->setGroups(['fullAccount', 'partialContact', 'Default'])
+        );
+
         return $this->handleView($view);
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ContactBundle\Tests\Functional\Controller;
 
+use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\ContactBundle\Entity\Account;
 use Sulu\Bundle\ContactBundle\Entity\AccountAddress;
 use Sulu\Bundle\ContactBundle\Entity\AccountContact;
@@ -38,6 +39,11 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 class AccountControllerTest extends SuluTestCase
 {
     /**
+     * @var EntityManager
+     */
+    private $em;
+
+    /**
      * @var Account
      */
     private $account;
@@ -56,6 +62,51 @@ class AccountControllerTest extends SuluTestCase
      * @var Account
      */
     private $parentAccount;
+
+    /**
+     * @var UrlType
+     */
+    private $urlType;
+
+    /**
+     * @var Url
+     */
+    private $url;
+
+    /**
+     * @var EmailType
+     */
+    private $emailType;
+
+    /**
+     * @var Email
+     */
+    private $email;
+
+    /**
+     * @var PhoneType
+     */
+    private $phoneType;
+
+    /**
+     * @var FaxType
+     */
+    private $faxType;
+
+    /**
+     * @var Country
+     */
+    private $country;
+
+    /**
+     * @var AddressType
+     */
+    private $addressType;
+
+    /**
+     * @var Address
+     */
+    private $address;
 
     public function setUp()
     {
@@ -238,6 +289,21 @@ class AccountControllerTest extends SuluTestCase
         $file->setMedia($this->logo);
         $this->em->persist($this->logo);
         $this->em->persist($file);
+    }
+
+    public function testCgetSerializationExclusions()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'GET',
+            '/api/accounts'
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertArrayNotHasKey('account', $response['_embedded']['accounts'][0]['accountContacts'][0]['contact']);
+        $this->assertArrayNotHasKey('account', $response['_embedded']['accounts'][0]['contacts'][0]);
     }
 
     public function testGetById()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #1471 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the recursion appeared on the action `/admin/api/accounts` by specifically defining the SerializationContexts which should be used.

#### BC Breaks/Deprecations

The response of the action `/admin/api/accounts` does not contain as much information about the contacts assigned to the account as it did before.

