### PR TITLE
Fix required version of PHP to support only ^5.5 and ^7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2128 [All]                 Fix required version of PHP to support only ^5.5 and ^7.0
     * ENHANCEMENT #2122 [All]                 Disable xdebug on Travis to speed up composer and tests
     * ENHANCEMENT #2120 [All]                 Change bundle tests to use their own phpunit config and move `SYMFONY_DEPRECATIONS_HELPER` var into
     * ENHANCEMENT #2121 [All]                 Cache composer cache dir and prefer dist downloads on Travis

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+        "php": "^5.5 || ^7.0",
         "cboden/ratchet": "0.3.*",
         "doctrine/orm": "2.5.*",
         "doctrine/phpcr-bundle": "~1.2.0",
@@ -25,7 +26,6 @@
         "liip/theme-bundle": "1.3.*",
         "massive/search-bundle": "dev-develop",
         "sulu/document-manager": "dev-develop",
-        "php": ">=5.5",
         "sensio/framework-extra-bundle": "3.0.*",
         "stof/doctrine-extensions-bundle": "1.1.*",
         "symfony-cmf/routing-bundle": "1.2.*",

--- a/src/Sulu/Bundle/AdminBundle/composer.json
+++ b/src/Sulu/Bundle/AdminBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "sulu/sulu": "dev-develop"
     },
     "require-dev": {

--- a/src/Sulu/Bundle/CategoryBundle/composer.json
+++ b/src/Sulu/Bundle/CategoryBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "doctrine/orm": "2.4.*",
         "friendsofsymfony/rest-bundle": "1.4.*",
         "sulu/sulu": "dev-develop",

--- a/src/Sulu/Bundle/ContactBundle/composer.json
+++ b/src/Sulu/Bundle/ContactBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "doctrine/orm": "2.4.*",
         "friendsofsymfony/rest-bundle": "1.4.*",
         "friendsofsymfony/http-cache": "1.0.*",

--- a/src/Sulu/Bundle/ContentBundle/composer.json
+++ b/src/Sulu/Bundle/ContentBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
 
         "sulu/sulu": "dev-develop",
         "sulu/admin-bundle": "dev-develop",

--- a/src/Sulu/Bundle/GeneratorBundle/Resources/skeleton/sulu/other/composer.json.twig
+++ b/src/Sulu/Bundle/GeneratorBundle/Resources/skeleton/sulu/other/composer.json.twig
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "doctrine/orm": ">=2.2.3,<2.4-dev",
         "friendsofsymfony/rest-bundle": "@dev",
         "jms/serializer-bundle": "@dev",

--- a/src/Sulu/Bundle/LocationBundle/composer.json
+++ b/src/Sulu/Bundle/LocationBundle/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "sulu/sulu": "dev-develop",
         "sulu/admin-bundle": "dev-develop",
         "sulu/content-bundle": "dev-develop",

--- a/src/Sulu/Bundle/MediaBundle/composer.json
+++ b/src/Sulu/Bundle/MediaBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "doctrine/orm": "2.4.*",
         "stof/doctrine-extensions-bundle": "1.1.*",
         "sulu/sulu": "dev-develop",

--- a/src/Sulu/Bundle/ResourceBundle/composer.json
+++ b/src/Sulu/Bundle/ResourceBundle/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "doctrine/orm": "2.4.*",
         "friendsofsymfony/rest-bundle": "1.4.*",
         "friendsofsymfony/http-cache": "1.0.*",

--- a/src/Sulu/Bundle/SecurityBundle/composer.json
+++ b/src/Sulu/Bundle/SecurityBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "doctrine/orm": "2.4.*",
         "stof/doctrine-extensions-bundle": "1.1.*",
         "willdurand/hateoas-bundle": "0.3.*",

--- a/src/Sulu/Bundle/SnippetBundle/composer.json
+++ b/src/Sulu/Bundle/SnippetBundle/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "sulu/sulu": "dev-develop",
         "friendsofsymfony/rest-bundle": "~1.4",
         "sensio/framework-extra-bundle": "3.0.*",

--- a/src/Sulu/Bundle/TagBundle/composer.json
+++ b/src/Sulu/Bundle/TagBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "doctrine/orm": "2.4.*",
         "sulu/sulu": "dev-develop",
         "sulu/contact-bundle": "dev-develop",

--- a/src/Sulu/Bundle/TestBundle/composer.json
+++ b/src/Sulu/Bundle/TestBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "sulu/sulu": "dev-develop",
 
         "phpspec/prophecy-phpunit": "~1.0",

--- a/src/Sulu/Bundle/TranslateBundle/composer.json
+++ b/src/Sulu/Bundle/TranslateBundle/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
         "doctrine/orm": "2.4.*",
         "sulu/sulu": "dev-develop",
         "sulu/admin-bundle": "dev-develop",

--- a/src/Sulu/Bundle/WebsiteBundle/composer.json
+++ b/src/Sulu/Bundle/WebsiteBundle/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.5 || ^7.0",
 
         "sulu/sulu": "dev-develop",
 

--- a/src/Sulu/Bundle/WebsocketBundle/composer.json
+++ b/src/Sulu/Bundle/WebsocketBundle/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": "^5.5 || ^7.0"
     },
     "require-dev": {
         "symfony/symfony": "2.5.*",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2118 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fixes the `composer.json` files to correctly support only PHP `^5.5` and `^7.0`, so Sulu will not be installable in a future PHP 8 version :grin: 

#### Why?

Because `>=5.5` is wrong in terms of semver :smiley: 