### PR TITLE
Fix console dir determination to support new symfony distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * FEATURE     #1288 [All]                 Added deep-links for selection content-types
     * BUGFIX      #2131 [WebsiteBundle]       Fixed 'getTheme' error in ExceptionController
     * ENHANCEMENT #2131 [CoreBundle]          Added request attributes to extract data from request
+    * ENHANCEMENT #2130 [MediaBundle]         Add support for newer symfony distributions with `bin/` directory
     * BUGFIX      #2128 [All]                 Fix required version of PHP to support only ^5.5 and ^7.0
     * BUGFIX      #2126 [ContactBundle]       Excluded recursion in accounts REST API
     * BUGFIX      #2126 [All]                 Fixed firefox bug in label tick

--- a/src/Sulu/Bundle/MediaBundle/Composer/MediaScriptHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Composer/MediaScriptHandler.php
@@ -22,11 +22,11 @@ class MediaScriptHandler extends ScriptHandler
     public static function initBundle(CommandEvent $event)
     {
         $options = parent::getOptions($event);
-        $appDir = $options['symfony-app-dir'];
+        $consoleDir = isset($options['symfony-bin-dir']) ? $options['symfony-bin-dir'] : $options['symfony-app-dir'];
 
         parent::executeCommand(
             $event,
-            $appDir,
+            $consoleDir,
             'sulu:media:init'
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Expands console dir determination boundaries to newer symfony distribution possibilities.

#### Why?

As of 4.0 of Sensio Distribution Bundle (5.0 is default in Symfony 2.8 and 3.0) console "binary" has been moved to the `bin/` directory. In this case, `app/console` is no longer an option.
