### PR TITLE
Fixed behat context to create correct roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2156 [SecurityBundle]      Fixed behat context to create correct roles
     * BUGFIX      #2152 [ContentBundle]       Fixed not empty request body for delete history url 
     * FEATURE     #1288 [All]                 Added deep-links for selection content-types
     * BUGFIX      #2131 [WebsiteBundle]       Fixed 'getTheme' error in ExceptionController

--- a/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
+++ b/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
@@ -178,30 +178,13 @@ class SecurityContext extends BaseContext implements SnippetAcceptingContext
             return $role;
         }
 
-        $role = new Role();
-        $role->setName($name);
-        $role->setSystem($system);
-        $pool = $this->getContainer()->get('sulu_admin.admin_pool');
-        $securityContexts = $pool->getSecurityContexts();
-
-        $securityContextsFlat = [];
-        array_walk_recursive(
-            $securityContexts['Sulu'],
-            function ($value) use (&$securityContextsFlat) {
-                $securityContextsFlat[] = $value;
-            }
+        $this->execCommand(
+            'sulu:security:role:create',
+            [
+                'name' => $name,
+                'system' => 'Sulu',
+            ]
         );
-
-        foreach ($securityContextsFlat as $securityContext) {
-            $permission = new Permission();
-            $permission->setRole($role);
-            $permission->setContext($securityContext);
-            $permission->setPermissions(120);
-            $role->addPermission($permission);
-        }
-
-        $this->getEntityManager()->persist($role);
-        $this->getEntityManager()->flush();
 
         return $role;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Replaces the duplicated logic of creating a role in the Behat context with a simple command execution. Also fixes a regression causing the behat tests to fail, because the required UI elements were hidden due to missing permissions.

#### Why?

Behat tests were failing because of that, and it is seldom a good idea to duplicate code :grinning: 