### PR TITLE
Fixed route-validation in request processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG for Sulu
     * BUGIFX      #2141 [ContentBundle]       Fixed page gets immediately saved after generating URL
     * BUGFIX      #2156 [SecurityBundle]      Fixed behat context to create correct roles
     * BUGFIX      #2152 [ContentBundle]       Fixed not empty request body for delete history url 
+    * BUGFIX      #2157 [CustomUrlBundle]     Fixed route-validation in request processor
     * FEATURE     #1288 [All]                 Added deep-links for selection content-types
     * BUGFIX      #2131 [WebsiteBundle]       Fixed 'getTheme' error in ExceptionController
     * ENHANCEMENT #2131 [CoreBundle]          Added request attributes to extract data from request

--- a/src/Sulu/Bundle/ContentBundle/Preview/PreviewMessageHandler.php
+++ b/src/Sulu/Bundle/ContentBundle/Preview/PreviewMessageHandler.php
@@ -281,7 +281,7 @@ class PreviewMessageHandler implements MessageHandlerInterface
         }
         $changes = $msg['data'];
 
-        $request = new Request(['webspaceKey' => $webspaceKey, 'locale' => $locale]);
+        $request = new Request(['webspace' => $webspaceKey, 'locale' => $locale]);
         $this->requestAnalyzer->analyze($request);
 
         foreach ($changes as $property => $data) {

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.BasePageDocument.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.BasePageDocument.xml
@@ -35,7 +35,7 @@
         <property name="shadowLocaleEnabled" type="boolean" serialized-name="shadowOn" groups="defaultPage"/>
         <property name="uuid" type="string" serialized-name="id" groups="defaultPage,smallPage,previewPage"/>
         <property name="structureType" type="string" groups="previewPage"/>
-        <property name="locale" type="string"/>
+        <property name="locale" type="string" groups="previewPage"/>
         <property name="path" type="string"/>
         <property name="internal" type="boolean" groups="defaultPage"/>
         <property name="webspaceName" type="string"/>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/PreviewControllerTest.php
@@ -116,10 +116,10 @@ class PreviewControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
-        $client->request('POST', '/api/nodes?&webspace=sulu_io&language=en', $data);
+        $client->request('POST', '/api/nodes?&webspace=sulu_io&language=de_at', $data);
         $response = json_decode($client->getResponse()->getContent());
 
-        $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=en');
+        $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=de_at');
         $response = $client->getResponse()->getContent();
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
@@ -141,10 +141,10 @@ class PreviewControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&language=de_at', $data);
         $response = json_decode($client->getResponse()->getContent());
 
-        $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=en');
+        $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=de_at');
         $response = $client->getResponse()->getContent();
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
@@ -168,10 +168,10 @@ class PreviewControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&language=de_at', $data);
         $response = json_decode($client->getResponse()->getContent());
 
-        $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=en');
+        $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=de_at');
         $response = $client->getResponse()->getContent();
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Preview/DoctrineCacheProviderTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Preview/DoctrineCacheProviderTest.php
@@ -139,6 +139,7 @@ class DoctrineCacheProviderTest extends SuluTestCase
         $data = json_decode($this->dataCache->fetch($this->getId(1, $data[0]->getUuid(), 'en')), true);
         $this->assertEquals('Testtitle', $data['document']['structure']['title']);
         $this->assertEquals('overview', $data['document']['structureType']);
+        $this->assertEquals('en', $data['document']['locale']);
     }
 
     public function testSaveStructure()
@@ -230,6 +231,7 @@ class DoctrineCacheProviderTest extends SuluTestCase
         $result = $this->cache->fetchStructure(1, $data[0]->getUuid(), 'sulu_io', 'en');
         $this->assertEquals('Testtitle', $result->getPropertyValue('title'));
         $this->assertEquals('overview', $result->getKey());
+        $this->assertEquals('en', $result->getLanguageCode());
     }
 
     public function testFetchNotExists()

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Preview/PreviewTest.php
@@ -63,7 +63,7 @@ class PreviewTest extends SuluTestCase
         $requestAnalyzer = $this->getContainer()->get('sulu_core.webspace.request_analyzer');
 
         $webspace = $this->getContainer()->get('sulu_core.webspace.webspace_manager')->findWebspaceByKey('sulu_io');
-        $localization = $webspace->getLocalization('en');
+        $localization = $webspace->getLocalization('de_at');
 
         $attributes = new \ReflectionProperty($requestAnalyzer, 'attributes');
         $attributes->setAccessible(true);
@@ -124,8 +124,8 @@ class PreviewTest extends SuluTestCase
             ],
         ];
 
-        $data[0] = $this->mapper->save($data[0], 'overview', 'sulu_io', 'en', 1);
-        $data[1] = $this->mapper->save($data[1], 'overview', 'sulu_io', 'en', 1);
+        $data[0] = $this->mapper->save($data[0], 'overview', 'sulu_io', 'de_at', 1);
+        $data[1] = $this->mapper->save($data[1], 'overview', 'sulu_io', 'de_at', 1);
 
         return $data;
     }
@@ -186,14 +186,14 @@ class PreviewTest extends SuluTestCase
     {
         $data = $this->prepareData();
 
-        $content = $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $content = $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
 
         // check result
         $this->assertEquals('Test1', $content->getPropertyValue('title'));
         $this->assertEquals('Lorem Ipsum dolorem apsum', $content->getPropertyValue('article'));
 
         // check cache
-        $cachedPage = $this->previewCache->fetchStructure(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $cachedPage = $this->previewCache->fetchStructure(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $this->assertNotNull($cachedPage);
         $this->assertEquals('Test1', $cachedPage->getPropertyValue('title'));
         $this->assertEquals('Lorem Ipsum dolorem apsum', $cachedPage->getPropertyValue('article'));
@@ -203,20 +203,20 @@ class PreviewTest extends SuluTestCase
     {
         $data = $this->prepareData();
 
-        $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'en');
-        $this->assertTrue($this->previewCache->contains(1, $data[0]->getUuid(), 'sulu_io', 'en'));
+        $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
+        $this->assertTrue($this->previewCache->contains(1, $data[0]->getUuid(), 'sulu_io', 'de_at'));
 
-        $this->preview->stop(1, $data[0]->getUuid(), 'sulu_io', 'en');
-        $this->assertFalse($this->previewCache->contains(1, $data[0]->getUuid(), 'sulu_io', 'en'));
+        $this->preview->stop(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
+        $this->assertFalse($this->previewCache->contains(1, $data[0]->getUuid(), 'sulu_io', 'de_at'));
     }
 
     public function testUpdate()
     {
         $data = $this->prepareData();
 
-        $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'en');
-        $this->preview->updateProperty(1, $data[0]->getUuid(), 'sulu_io', 'en', 'title', 'aaaa');
-        $content = $this->preview->getChanges(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
+        $this->preview->updateProperty(1, $data[0]->getUuid(), 'sulu_io', 'de_at', 'title', 'aaaa');
+        $content = $this->preview->getChanges(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
 
         // check result
         $this->assertEquals(
@@ -225,8 +225,8 @@ class PreviewTest extends SuluTestCase
         );
 
         // check cache
-        $this->assertTrue($this->previewCache->contains(1, $data[0]->getUuid(), 'sulu_io', 'en'));
-        $content = $this->previewCache->fetchStructure(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $this->assertTrue($this->previewCache->contains(1, $data[0]->getUuid(), 'sulu_io', 'de_at'));
+        $content = $this->previewCache->fetchStructure(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $this->assertEquals('aaaa', $content->getPropertyValue('title'));
         $this->assertEquals('Lorem Ipsum dolorem apsum', $content->getPropertyValue('article'));
     }
@@ -235,12 +235,12 @@ class PreviewTest extends SuluTestCase
     {
         $data = $this->prepareData();
 
-        $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $this->preview->updateProperty(
             1,
             $data[0]->getUuid(),
             'sulu_io',
-            'en',
+            'de_at',
             'block,0,article,0',
             'New-Block-Article-1-1'
         );
@@ -248,7 +248,7 @@ class PreviewTest extends SuluTestCase
             1,
             $data[0]->getUuid(),
             'sulu_io',
-            'en',
+            'de_at',
             'block,0,article,1',
             'New-Block-Article-1-2'
         );
@@ -256,7 +256,7 @@ class PreviewTest extends SuluTestCase
             1,
             $data[0]->getUuid(),
             'sulu_io',
-            'en',
+            'de_at',
             'block,0,title',
             'New-Block-Title-1'
         );
@@ -264,7 +264,7 @@ class PreviewTest extends SuluTestCase
             1,
             $data[0]->getUuid(),
             'sulu_io',
-            'en',
+            'de_at',
             'block,1,title',
             'New-Block-Title-2'
         );
@@ -272,7 +272,7 @@ class PreviewTest extends SuluTestCase
             1,
             $data[0]->getUuid(),
             'sulu_io',
-            'en'
+            'de_at'
         );
 
         // check result
@@ -304,8 +304,8 @@ class PreviewTest extends SuluTestCase
         );
 
         // check cache
-        $this->assertTrue($this->previewCache->contains(1, $data[0]->getUuid(), 'sulu_io', 'en'));
-        $content = $this->previewCache->fetchStructure(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $this->assertTrue($this->previewCache->contains(1, $data[0]->getUuid(), 'sulu_io', 'de_at'));
+        $content = $this->previewCache->fetchStructure(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $this->assertEquals(
             [
                 [
@@ -333,12 +333,12 @@ class PreviewTest extends SuluTestCase
     {
         $data = $this->prepareData();
 
-        $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $response = $this->preview->render(
             1,
             $data[0]->getUuid(),
             'sulu_io',
-            'en'
+            'de_at'
         );
 
         $expected = $this->render(
@@ -369,12 +369,12 @@ class PreviewTest extends SuluTestCase
         $data = $this->prepareData();
 
         // start preview from FORM
-        $content = $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $content = $this->preview->start(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $this->assertEquals('Test1', $content->getPropertyValue('title'));
         $this->assertEquals('Lorem Ipsum dolorem apsum', $content->getPropertyValue('article'));
 
         // render PREVIEW
-        $response = $this->preview->render(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $response = $this->preview->render(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $expected = $this->render(
             'Test1',
             'Lorem Ipsum dolorem apsum',
@@ -398,16 +398,16 @@ class PreviewTest extends SuluTestCase
         $this->assertEquals($expected, $response);
 
         // change a property in FORM
-        $content = $this->preview->updateProperty(1, $data[0]->getUuid(), 'sulu_io', 'en', 'title', 'New Title');
+        $content = $this->preview->updateProperty(1, $data[0]->getUuid(), 'sulu_io', 'de_at', 'title', 'New Title');
         $this->assertEquals('New Title', $content->getPropertyValue('title'));
         $this->assertEquals('Lorem Ipsum dolorem apsum', $content->getPropertyValue('article'));
 
-        $content = $this->preview->updateProperty(1, $data[0]->getUuid(), 'sulu_io', 'en', 'article', 'asdf');
+        $content = $this->preview->updateProperty(1, $data[0]->getUuid(), 'sulu_io', 'de_at', 'article', 'asdf');
         $this->assertEquals('New Title', $content->getPropertyValue('title'));
         $this->assertEquals('asdf', $content->getPropertyValue('article'));
 
         // update PREVIEW
-        $changes = $this->preview->getChanges(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $changes = $this->preview->getChanges(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $this->assertEquals(2, count($changes));
         $this->assertEquals(
             [['property' => 'title', 'html' => 'New Title'], ['property' => 'title', 'html' => 'PREF: New Title']],
@@ -416,11 +416,11 @@ class PreviewTest extends SuluTestCase
         $this->assertEquals([['property' => 'article', 'html' => 'asdf']], $changes['article']);
 
         // update PREVIEW
-        $changes = $this->preview->getChanges(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $changes = $this->preview->getChanges(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $this->assertEquals(0, count($changes));
 
         // rerender PREVIEW
-        $response = $this->preview->render(1, $data[0]->getUuid(), 'sulu_io', 'en');
+        $response = $this->preview->render(1, $data[0]->getUuid(), 'sulu_io', 'de_at');
         $expected = $this->render(
             'New Title',
             'asdf',

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/routing.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/routing.xml
@@ -97,6 +97,8 @@
         <service id="sulu_custom_urls.request_processor"
                  class="Sulu\Bundle\CustomUrlBundle\Request\CustomUrlRequestProcessor">
             <argument type="service" id="sulu_custom_urls.manager"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="string">%kernel.environment%</argument>
 
             <tag name="sulu.context" context="website"/>
             <tag name="sulu.request_attributes"/>

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
@@ -31,6 +31,7 @@ class RouteProviderCompilerPass implements CompilerPassInterface
             $container->setDefinition(
                 'sulu_website.provider.content',
                 new Definition('Sulu\Bundle\WebsiteBundle\Routing\ContentRouteProvider', [
+                    new Reference('sulu.content.mapper'),
                     new Reference('sulu_core.webspace.request_analyzer'),
                 ])
             );

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -83,7 +83,11 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
     public function resolveForPreview($webspaceKey, $locale)
     {
         // take first portal url
-        $portalInformation = $this->webspaceManager->getPortalInformations($this->environment);
+        $portalInformation = $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale(
+            $webspaceKey,
+            $locale,
+            $this->environment
+        );
         $portalUrl = array_keys($portalInformation)[0];
 
         return [

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Sitemap/SitemapXMLGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Sitemap/SitemapXMLGeneratorTest.php
@@ -57,7 +57,7 @@ class SitemapXMLGeneratorTest extends SuluTestCase
 
         $date = '2016-03-01';
         $this->assertContains(
-            '<url><loc>http://test.lo</loc><lastmod>' . $date . '</lastmod><xhtml:link rel="alternate" hreflang="en" href="http://test.lo"/><xhtml:link rel="alternate" hreflang="x-default" href="http://test.lo"/><xhtml:link rel="alternate" hreflang="en-us" href="http://test.lo/en-us"/></url><url><loc>http://test.lo/en-us</loc><lastmod>' . $date . '</lastmod><xhtml:link rel="alternate" hreflang="en" href="http://test.lo"/><xhtml:link rel="alternate" hreflang="x-default" href="http://test.lo"/><xhtml:link rel="alternate" hreflang="en-us" href="http://test.lo/en-us"/></url>',
+            '<url><loc>http://test.lo/en</loc><lastmod>2016-03-01</lastmod><xhtml:link rel="alternate" hreflang="en" href="http://test.lo/en"/><xhtml:link rel="alternate" hreflang="x-default" href="http://test.lo/en"/><xhtml:link rel="alternate" hreflang="en-us" href="http://test.lo/en-us"/></url><url><loc>http://test.lo/en-us</loc><lastmod>2016-03-01</lastmod><xhtml:link rel="alternate" hreflang="en" href="http://test.lo/en"/><xhtml:link rel="alternate" hreflang="x-default" href="http://test.lo/en"/><xhtml:link rel="alternate" hreflang="en-us" href="http://test.lo/en-us"/></url>',
             $content
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
@@ -129,7 +129,8 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveForPreview()
     {
-        $this->webspaceManager->getPortalInformations('dev')->willReturn(['sulu.io/de' => []]);
+        $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale('sulu_io', 'de', 'dev')
+            ->willReturn(['sulu.io/de' => []]);
 
         $request = new \Symfony\Component\HttpFoundation\Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
@@ -155,7 +156,8 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveForPreviewWithRequestParameter()
     {
-        $this->webspaceManager->getPortalInformations('dev')->willReturn(['sulu.io/de' => []]);
+        $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale('sulu_io', 'de', 'dev')
+            ->willReturn(['sulu.io/de' => []]);
 
         $request = new \Symfony\Component\HttpFoundation\Request(['test' => 1], ['test' => 2]);
         $this->requestStack->getCurrentRequest()->willReturn($request);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -42,12 +42,12 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $localization->setLanguage('de');
 
         $structure = $this->getStructureMock($uuid, null, 1);
-
         $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix, $localization);
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -74,13 +74,12 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $localization->setLanguage('de');
 
         $structure = $this->getStructureMock($uuid, null, 1);
-
         $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix, $localization);
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
 
-        $activeTheme = $this->getActiveThemeMock();
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -107,13 +106,12 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $localization->setLanguage('de');
 
         $structure = $this->getStructureMock($uuid);
-
         $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix, $localization);
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
 
-        $activeTheme = $this->getActiveThemeMock();
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -129,7 +127,6 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         // Set up test
         $path = '';
         $prefix = '/de';
-        $uuid = 1;
         $portal = new Portal();
         $portal->setKey('portal');
         $theme = new Theme();
@@ -138,20 +135,10 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $webspace->setTheme($theme);
         $portal->setWebspace($webspace);
 
-        $structure = $this->getStructureMock(
-            $uuid,
-            null,
-            Structure::STATE_PUBLISHED,
-            Structure::NODE_TYPE_CONTENT,
-            false
-        );
-
+        $contentMapper = $this->getContentMapperMock();
         $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix);
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
 
-        $activeTheme = $this->getActiveThemeMock();
-
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -187,10 +174,11 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             'sulu.lo/de/',
             'sulu.lo/de'
         );
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -221,13 +209,12 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $localization->setLanguage('de');
 
         $structure = $this->getStructureMock($uuid);
-
         $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix, $localization, $path);
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
 
-        $activeTheme = $this->getActiveThemeMock();
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -252,6 +239,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $webspace->setTheme($theme);
         $portal->setWebspace($webspace);
 
+        $structure = $this->getStructureMock($uuid);
         $requestAnalyzer = $this->getRequestAnalyzerMock(
             $portal,
             $path,
@@ -262,9 +250,11 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             'sulu.lo/en-us'
         );
         $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue(null));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue(null));
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -295,12 +285,13 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $localization->setLanguage('de');
 
         $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix, $localization);
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will(
-            $this->returnValue(new ResourceLocatorNotFoundException())
-        );
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will(
+            $this->throwException(new ResourceLocatorNotFoundException())
+        );
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -333,10 +324,11 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             'sulu-redirect.lo',
             'sulu.lo'
         );
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue(null));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue(null));
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -379,10 +371,11 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $prefix,
             $locale
         );
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -424,10 +417,11 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $prefix,
             $locale
         );
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -466,10 +460,11 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             'sulu.lo',
             'sulu.lo/en-us'
         );
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->willReturn($structure);
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -508,10 +503,11 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             'sulu.lo',
             'sulu.lo/en-us'
         );
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue($structure));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->willReturn($structure);
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -549,10 +545,13 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             'sulu.lo',
             'sulu.lo/en-us'
         );
-        $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue(new ResourceLocatorMovedException('/new-test', '123-123-123')));
-        $activeTheme = $this->getActiveThemeMock();
 
-        $portalRouteProvider = new ContentRouteProvider($requestAnalyzer, $activeTheme);
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will(
+            $this->throwException(new ResourceLocatorMovedException('/new-test', '123-123-123'))
+        );
+
+        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
 
         $request = $this->getRequestMock($path);
 
@@ -572,15 +571,14 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $uuid,
         $resourceLocator = null,
         $state = Structure::STATE_PUBLISHED,
-        $type = Structure::NODE_TYPE_CONTENT,
-        $hasTranslation = true
+        $type = Structure::NODE_TYPE_CONTENT
     ) {
         $structure = $this->prophesize(PageBridge::class);
 
         $structure->getUuid()->willReturn($uuid);
         $structure->getNodeState()->willReturn($state);
         $structure->getNodeType()->willReturn($type);
-        $structure->getHasTranslation()->willReturn($hasTranslation);
+        $structure->getHasTranslation()->willReturn(true);
         $structure->getController()->willReturn('');
         $structure->getKey()->willReturn('key');
         $structure->getResourceLocator()->willReturn($resourceLocator);
@@ -656,14 +654,6 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         );
 
         return $contentMapper;
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function getActiveThemeMock()
-    {
-        return $this->getMock('\Liip\ThemeBundle\ActiveTheme', [], [], '', false);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -81,7 +81,14 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
                 $scheme
             );
         } elseif (strpos($url, '/') === 0 && $this->requestAnalyzer) {
-            return rtrim($this->requestAnalyzer->getResourceLocatorPrefix() . $url, '/');
+            return $this->webspaceManager->findUrlByResourceLocator(
+                $url,
+                $this->environment,
+                $locale ?: $this->requestAnalyzer->getCurrentLocalization()->getLocalization(),
+                $this->requestAnalyzer->getWebspace()->getKey(),
+                $domain,
+                $scheme
+            );
         }
 
         return $url;
@@ -92,15 +99,7 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
      */
     public function getContentRootPath($full = false)
     {
-        if ($this->requestAnalyzer !== null) {
-            if ($full) {
-                return $this->requestAnalyzer->getPortalUrl();
-            } else {
-                return $this->requestAnalyzer->getResourceLocatorPrefix();
-            }
-        } else {
-            return '/';
-        }
+        return $this->getContentPath('/');
     }
 
     /**

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -69,6 +69,12 @@ class Localization implements \JsonSerializable, ArrayableInterface
      */
     private $xDefault;
 
+    public function __construct($language = null, $country = null)
+    {
+        $this->language = $language;
+        $this->country = $country;
+    }
+
     /**
      * Sets the country of this localization.
      *

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/AbstractRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/AbstractRequestProcessor.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Analyzer\Attributes;
+
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\PortalInformation;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Base class for request processors.
+ * Provides functionality to process a single portal-information.
+ */
+abstract class AbstractRequestProcessor implements RequestProcessorInterface
+{
+    /**
+     * Returns the request attributes for given portal information.
+     *
+     * @param Request $request
+     * @param PortalInformation $portalInformation
+     * @param array $additionalAttributes
+     *
+     * @return RequestAttributes
+     */
+    protected function processPortalInformation(
+        Request $request,
+        PortalInformation $portalInformation,
+        $additionalAttributes = []
+    ) {
+        $attributes = ['requestUri' => $request->getUri()];
+
+        if ($portalInformation === null) {
+            return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+        }
+
+        if (null !== $localization = $portalInformation->getLocalization()) {
+            $request->setLocale($portalInformation->getLocalization()->getLocalization());
+        }
+
+        $attributes['portalInformation'] = $portalInformation;
+
+        $attributes['getParameter'] = $request->query->all();
+        $attributes['postParameter'] = $request->request->all();
+
+        $attributes['matchType'] = $portalInformation->getType();
+        $attributes['redirect'] = $portalInformation->getRedirect();
+        $attributes['analyticsKey'] = $portalInformation->getAnalyticsKey();
+
+        $attributes['portalUrl'] = $portalInformation->getUrl();
+        $attributes['webspace'] = $portalInformation->getWebspace();
+
+        if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_REDIRECT) {
+            return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+        }
+
+        $attributes['localization'] = $portalInformation->getLocalization();
+        $attributes['portal'] = $portalInformation->getPortal();
+        $attributes['segment'] = $portalInformation->getSegment();
+
+        list($resourceLocator, $format) = $this->getResourceLocatorFromRequest(
+            $portalInformation,
+            $request
+        );
+
+        $attributes['resourceLocator'] = $resourceLocator;
+        $attributes['format'] = $format;
+
+        $host = $request->getHost();
+        if ($portalInformation->getType() !== RequestAnalyzerInterface::MATCH_TYPE_WILDCARD) {
+            $urlInfo = parse_url($request->getScheme() . '://' . $portalInformation->getUrl());
+            $host = $urlInfo['host'];
+        }
+        $attributes['resourceLocatorPrefix'] = substr($portalInformation->getUrl(), strlen($host));
+
+        if (null !== $format) {
+            $request->setRequestFormat($format);
+        }
+
+        return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+    }
+
+    /**
+     * Returns resource locator and format of current request.
+     *
+     * @param PortalInformation $portalInformation
+     * @param Request $request
+     *
+     * @return array
+     */
+    private function getResourceLocatorFromRequest(PortalInformation $portalInformation, Request $request)
+    {
+        $path = $request->getPathInfo();
+
+        // extract file and extension info
+        $pathParts = explode('/', $path);
+        $fileInfo = explode('.', array_pop($pathParts));
+
+        $path = rtrim(implode('/', $pathParts), '/') . '/' . $fileInfo[0];
+        $formatResult = null;
+        if (count($fileInfo) > 1) {
+            $formatResult = end($fileInfo);
+        }
+
+        $resourceLocator = substr(
+            $request->getHost() . $path,
+            strlen($portalInformation->getUrl())
+        );
+
+        return [$resourceLocator, $formatResult];
+    }
+}

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -10,13 +10,8 @@
 
 namespace Sulu\Component\Webspace\Analyzer\Attributes;
 
-use PHPCR\RepositoryException;
-use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Content\Exception\ResourceLocatorMovedException;
-use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Webspace\Analyzer\Exception\UrlMatchNotFoundException;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Extracts attributes from request for the sulu-website.
  */
-class WebsiteRequestProcessor implements RequestProcessorInterface
+class WebsiteRequestProcessor extends AbstractRequestProcessor
 {
     /**
      * @var WebspaceManagerInterface
@@ -64,8 +59,6 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
 
         if (count($portalInformations) === 0) {
             return new RequestAttributes();
-        } elseif (count($portalInformations) === 1) {
-            return $this->processPortalInformation($request, reset($portalInformations));
         }
 
         usort(
@@ -75,113 +68,7 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
             }
         );
 
-        $redirectTypes = [RequestAnalyzerInterface::MATCH_TYPE_FULL, RequestAnalyzerInterface::MATCH_TYPE_PARTIAL];
-
-        foreach ($portalInformations as $portalInformation) {
-            // take first none full match
-            if (!in_array($portalInformation->getType(), $redirectTypes)) {
-                return $this->processPortalInformation($request, $portalInformation);
-            }
-
-            // if there exists a resource-locator take this portal
-            if (null !== $content = $this->checkForResourceLocator($request, $portalInformation)) {
-                return $this->processPortalInformation($request, $portalInformation, $content);
-            }
-        }
-
-        return new RequestAttributes();
-    }
-
-    /**
-     * Returns the request attributes for given portal information.
-     *
-     * @param Request $request
-     * @param PortalInformation $portalInformation
-     * @param mixed $content
-     *
-     * @return RequestAttributes
-     */
-    protected function processPortalInformation(
-        Request $request,
-        PortalInformation $portalInformation,
-        $content = null
-    ) {
-        $attributes = ['requestUri' => $request->getUri(), 'content' => $content];
-
-        if ($portalInformation === null) {
-            return new RequestAttributes($attributes);
-        }
-
-        if (null !== $localization = $portalInformation->getLocalization()) {
-            $request->setLocale($portalInformation->getLocalization()->getLocalization());
-        }
-
-        $attributes['portalInformation'] = $portalInformation;
-
-        $attributes['getParameter'] = $request->query->all();
-        $attributes['postParameter'] = $request->request->all();
-
-        $attributes['matchType'] = $portalInformation->getType();
-        $attributes['redirect'] = $portalInformation->getRedirect();
-        $attributes['analyticsKey'] = $portalInformation->getAnalyticsKey();
-
-        $attributes['portalUrl'] = $portalInformation->getUrl();
-        $attributes['webspace'] = $portalInformation->getWebspace();
-
-        if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_REDIRECT) {
-            return new RequestAttributes($attributes);
-        }
-
-        $attributes['localization'] = $portalInformation->getLocalization();
-        $attributes['portal'] = $portalInformation->getPortal();
-        $attributes['segment'] = $portalInformation->getSegment();
-
-        list($resourceLocator, $format) = $this->getResourceLocatorFromRequest(
-            $portalInformation,
-            $request
-        );
-
-        $attributes['resourceLocator'] = $resourceLocator;
-        $attributes['format'] = $format;
-        $attributes['resourceLocatorPrefix'] = substr($portalInformation->getUrl(), strlen($request->getHost()));
-
-        if (null !== $format) {
-            $request->setRequestFormat($format);
-        }
-
-        return new RequestAttributes($attributes);
-    }
-
-    /**
-     * Returns the content if a route exists.
-     *
-     * @param Request $request
-     * @param PortalInformation $portalInformation
-     *
-     * @return StructureInterface|void
-     */
-    protected function checkForResourceLocator(Request $request, PortalInformation $portalInformation)
-    {
-        list($resourceLocator, $format) = $this->getResourceLocatorFromRequest(
-            $portalInformation,
-            $request
-        );
-
-        try {
-            $content = $this->contentMapper->loadByResourceLocator(
-                rtrim($resourceLocator, '/'),
-                $portalInformation->getWebspaceKey(),
-                $portalInformation->getLocale()
-            );
-        } catch (ResourceLocatorNotFoundException $ex) {
-            return;
-        } catch (ResourceLocatorMovedException $ex) {
-            return $ex;
-        } catch (RepositoryException $ex) {
-            return;
-        }
-
-        return $content;
+        return $this->processPortalInformation($request, reset($portalInformations));
     }
 
     /**
@@ -194,35 +81,5 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
         }
 
         return true;
-    }
-
-    /**
-     * Returns resource locator and format of current request.
-     *
-     * @param PortalInformation $portalInformation
-     * @param Request $request
-     *
-     * @return array
-     */
-    private function getResourceLocatorFromRequest(PortalInformation $portalInformation, Request $request)
-    {
-        $path = $request->getPathInfo();
-
-        // extract file and extension info
-        $pathParts = explode('/', $path);
-        $fileInfo = explode('.', array_pop($pathParts));
-
-        $path = rtrim(implode('/', $pathParts), '/') . '/' . $fileInfo[0];
-        $formatResult = null;
-        if (count($fileInfo) > 1) {
-            $formatResult = end($fileInfo);
-        }
-
-        $resourceLocator = substr(
-            $request->getHost() . $path,
-            strlen($portalInformation->getUrl())
-        );
-
-        return [$resourceLocator, $formatResult];
     }
 }

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Webspace\Manager;
 
-use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Webspace;
@@ -88,20 +87,27 @@ class WebspaceCollection implements \IteratorAggregate
      * Returns the portal informations for the given environment.
      *
      * @param $environment string The environment to deliver
+     * @param array|null $types Defines which typr of portals are requested (null for all)
      *
-     * @throws \InvalidArgumentException
-     *
-     * @return PortalInformation[]
+     * @return \Sulu\Component\Webspace\PortalInformation[]
      */
-    public function getPortalInformations($environment)
+    public function getPortalInformations($environment, $types = null)
     {
         if (!isset($this->portalInformations[$environment])) {
             throw new \InvalidArgumentException(sprintf(
                 'Unknown portal environment "%s"', $environment
             ));
         }
+        if ($types === null) {
+            return $this->portalInformations[$environment];
+        }
 
-        return $this->portalInformations[$environment];
+        return array_filter(
+            $this->portalInformations[$environment],
+            function (PortalInformation $portalInformation) use ($types) {
+                return in_array($portalInformation->getType(), $types);
+            }
+        );
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -352,7 +352,7 @@ class WebspaceCollectionBuilder
                 $portal->getWebspace()->getDefaultSegment(),
                 $urlRedirect,
                 $urlAnalyticsKey,
-                $url->isMain(),
+                false, // partial matches cannot be main
                 $url->getUrl()
             );
         }

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -122,6 +122,20 @@ class WebspaceManager implements WebspaceManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function findPortalInformationsByWebspaceKeyAndLocale($webspaceKey, $locale, $environment)
+    {
+        return array_filter(
+            $this->getWebspaceCollection()->getPortalInformations($environment),
+            function (PortalInformation $portalInformation) use ($webspaceKey, $locale) {
+                return $portalInformation->getWebspace()->getKey() === $webspaceKey
+                       && $portalInformation->getLocale() === $locale;
+            }
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findUrlsByResourceLocator(
         $resourceLocator,
         $environment,
@@ -131,7 +145,14 @@ class WebspaceManager implements WebspaceManagerInterface
         $scheme = 'http'
     ) {
         $urls = [];
-        $portals = $this->getWebspaceCollection()->getPortalInformations($environment);
+        $portals = $this->getWebspaceCollection()->getPortalInformations(
+            $environment,
+            [
+                RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
+                RequestAnalyzerInterface::MATCH_TYPE_REDIRECT,
+            ]
+        );
         foreach ($portals as $url => $portalInformation) {
             $sameLocalization = $portalInformation->getLocalization()->getLocalization() === $languageCode;
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
@@ -156,7 +177,14 @@ class WebspaceManager implements WebspaceManagerInterface
         $scheme = 'http'
     ) {
         $urls = [];
-        $portals = $this->getWebspaceCollection()->getPortalInformations($environment);
+        $portals = $this->getWebspaceCollection()->getPortalInformations(
+            $environment,
+            [
+                RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
+                RequestAnalyzerInterface::MATCH_TYPE_REDIRECT,
+            ]
+        );
         foreach ($portals as $url => $portalInformation) {
             $sameLocalization = (
                 $portalInformation->getLocalization() === null

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
@@ -60,6 +60,17 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
     public function findPortalInformationsByUrl($url, $environment);
 
     /**
+     * Returns all portal which matches the given webspace-key and locale.
+     *
+     * @param string $webspaceKey The webspace-key which the portal should match
+     * @param string $locale The locale which the portal should match
+     * @param string $environment The environment in which the url should be searched
+     *
+     * @return \Sulu\Component\Webspace\PortalInformation[]
+     */
+    public function findPortalInformationsByWebspaceKeyAndLocale($webspaceKey, $locale, $environment);
+
+    /**
      * Returns all possible urls for resourcelocator.
      *
      * @param string $resourceLocator

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -200,6 +200,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $request->query = new ParameterBag(['get' => 1]);
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
+        $request->expects($this->once())->method('getScheme')->willReturn('http');
         $request->expects($this->once())->method('setLocale')->with('de_at');
         $this->requestAnalyzer->analyze($request);
 
@@ -250,6 +251,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
         $request->expects($this->once())->method('setLocale')->with('de_at');
+        $request->expects($this->once())->method('getScheme')->willReturn('http');
 
         if ($expected['format']) {
             $request->expects($this->once())->method('setRequestFormat')->will(

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -190,6 +190,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $request->query = new ParameterBag(['get' => 1]);
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
+        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
 
         $attributes = $this->provider->process($request, new RequestAttributes());
 
@@ -238,6 +239,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $request->query = new ParameterBag(['get' => 1]);
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
+        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
 
         $attributes = $this->provider->process($request, new RequestAttributes());
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
@@ -128,6 +128,19 @@ class WebspaceCollectionTest extends \PHPUnit_Framework_TestCase
         $this->webspaceCollection->setPortalInformations($portalInformations);
     }
 
+    public function testGetPortalInformations()
+    {
+        $this->assertCount(1, $this->webspaceCollection->getPortalInformations('dev'));
+        $this->assertCount(
+            1,
+            $this->webspaceCollection->getPortalInformations('dev', [RequestAnalyzerInterface::MATCH_TYPE_FULL])
+        );
+        $this->assertCount(
+            0,
+            $this->webspaceCollection->getPortalInformations('dev', [RequestAnalyzerInterface::MATCH_TYPE_REDIRECT])
+        );
+    }
+
     public function testToArray()
     {
         $collectionArray = $this->webspaceCollection->toArray();

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -14,7 +14,9 @@ namespace Sulu\Component\Webspace\Tests\Unit;
 use Psr\Log\LoggerInterface;
 use Sulu\Component\Webspace\Loader\XmlFileLoader;
 use Sulu\Component\Webspace\Manager\WebspaceManager;
+use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Url\Replacer;
+use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\Filesystem\Filesystem;
 
 class WebspaceManagerTest extends WebspaceTestCase
@@ -368,6 +370,21 @@ class WebspaceManagerTest extends WebspaceTestCase
         } else {
             $this->assertNull($portalInformation);
         }
+    }
+
+    public function testFindPortalInformationsByWebspaceKeyAndLocale()
+    {
+        $portalInformations = $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale(
+            'sulu_io',
+            'de_at',
+            'dev'
+        );
+
+        $this->assertCount(1, $portalInformations);
+        $portalInformation = reset($portalInformations);
+
+        $this->assertEquals('sulu_io', $portalInformation->getWebspace()->getKey());
+        $this->assertEquals('de_at', $portalInformation->getLocale());
     }
 
     public function testFindPortalInformationByUrlWithSegment()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes routes which are not managed by sulu (custom-routes and error pages).

Also in this PR is:

* Route generation fixed for custom-urls
* Preview exception (non-object)

#### Why?

With the changes for custom-urls there was introduced a bug which causes undetected routes and webspace not exception.

#### To Do

- [x] prettify
- [x] tests

