### PR TITLE
Fixed saving of homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2171 [ContentBundle]       Fixed saving of homepage
     * BUGFIX      #2166 [WebsiteBundle]       Fixed analytics type change
     * BUGFIX      #2152 [ContentBundle]       Fixed not empty request body for delete history url
     * BUGIFX      #2141 [ContentBundle]       Fixed page gets immediately saved after generating URL

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -632,9 +632,23 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals($data[1]['title'], $response->_embedded->nodes[1]->title);
     }
 
-    public function testPutHome()
+    public function testPutHomeWithChildren()
     {
+        $data = [
+            'title' => 'Testtitle',
+            'template' => 'default',
+            'tags' => [
+                'tag1',
+                'tag2',
+            ],
+            'url' => '/test',
+            'article' => 'Test',
+        ];
+
         $client = $this->createAuthenticatedClient();
+
+        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
         $data = [
             'template' => 'default',

--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
+use Sulu\Bundle\ContentBundle\Document\HomeDocument;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\RedirectTypeBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
@@ -140,6 +141,10 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
         $document = $event->getDocument();
 
         if (!$this->supports($document)) {
+            return;
+        }
+
+        if ($document instanceof HomeDocument) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Types/Rlp/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/Rlp/Mapper/PhpcrMapper.php
@@ -59,10 +59,6 @@ class PhpcrMapper extends RlpMapper
     {
         $path = $document->getResourceSegment();
 
-        if ($path === '/') {
-            return;
-        }
-
         $webspaceKey = $this->documentInspector->getWebspace($document);
         $locale = $this->documentInspector->getLocale($document);
         $segmentKey = null;
@@ -75,10 +71,6 @@ class PhpcrMapper extends RlpMapper
                 $locale,
                 $segmentKey
             );
-
-            if ($routeNodePath === '/') {
-                return;
-            }
 
             $routeDocument = $this->documentManager->find(
                 $webspaceRouteRootPath . $routeNodePath,

--- a/src/Sulu/Component/Content/Types/Rlp/Strategy/RlpStrategy.php
+++ b/src/Sulu/Component/Content/Types/Rlp/Strategy/RlpStrategy.php
@@ -270,7 +270,7 @@ abstract class RlpStrategy implements RlpStrategyInterface
      */
     public function isValid($path, $webspaceKey, $languageCode, $segmentKey = null)
     {
-        return $path === '/' || $this->cleaner->validate($path) && $this->mapper->unique(
+        return $path !== '/' && $this->cleaner->validate($path) && $this->mapper->unique(
             $path,
             $webspaceKey,
             $languageCode,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a bug, which caused an error to be thrown when the homepage is saved saying that the resource locator is not valid. This only happened when there was already another page, apart from the homepage, created.

#### Why?

Because content manager might also want to change the homepage without an error :-)