### PR TITLE
Added validation of unused webspace locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #2183 [ContentBundle]       Added missing locale for loading route document
     * BUGIFX      #2178 [WebsiteBundle]       Added default IP anonymization for google analytics
+    * ENHANCEMENT #2171 [CoreBundle]          Added validation of unused webspace locales
     * BUGFIX      #2171 [ContentBundle]       Fixed saving of homepage
     * BUGFIX      #2172 [CustomUrlBundle]     Added check for custom-url placeholder
     * BUGFIX      #2166 [WebsiteBundle]       Fixed analytics type change

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## dev-develop
 
+### Webspace validation
+
+Webspaces which have unused localizations by portals will now be not valid and ignored. Remove this
+localizations or add them to a portal.
+
 ### New security permission for cache
  
 To be able to clear the cache the user need the permission LIVE in the

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -50,6 +50,9 @@
             <localizations>
                 <localization language="fr"/>
                 <localization language="de" country="at" default="true"/>
+                <localization language="de"/>
+                <localization language="en"/>
+                <localization language="en" country="us"/>
             </localizations>
 
             <environments>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/webspaces/test.io.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/webspaces/test.io.xml
@@ -48,6 +48,9 @@
 
             <localizations>
                 <localization language="de" country="at" default="true"/>
+                <localization language="en"/>
+                <localization language="en" country="us" shadow="auto"/>
+                <localization language="de"/>
             </localizations>
 
             <environments>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -49,7 +49,10 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at" default="true"/>
+                <localization language="en"/>
+                <localization language="en" country="us"/>
+                <localization language="de"/>
+                <localization language="de" country="at"/>
             </localizations>
 
             <environments>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -49,8 +49,10 @@
             </resource-locator>
 
             <localizations>
-                <localization language="en" default="true"/>
+                <localization language="en"/>
+                <localization language="en" country="us"/>
                 <localization language="de"/>
+                <localization language="de" country="at"/>
             </localizations>
 
             <environments>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Sitemap/SitemapXMLGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Sitemap/SitemapXMLGeneratorTest.php
@@ -55,7 +55,6 @@ class SitemapXMLGeneratorTest extends SuluTestCase
         $client->request('GET', 'http://test.lo/sitemap.xml');
         $content = $client->getResponse()->getContent();
 
-        $date = '2016-03-01';
         $this->assertContains(
             '<url><loc>http://test.lo/en</loc><lastmod>2016-03-01</lastmod><xhtml:link rel="alternate" hreflang="en" href="http://test.lo/en"/><xhtml:link rel="alternate" hreflang="x-default" href="http://test.lo/en"/><xhtml:link rel="alternate" hreflang="en-us" href="http://test.lo/en-us"/></url><url><loc>http://test.lo/en-us</loc><lastmod>2016-03-01</lastmod><xhtml:link rel="alternate" hreflang="en" href="http://test.lo/en"/><xhtml:link rel="alternate" hreflang="x-default" href="http://test.lo/en"/><xhtml:link rel="alternate" hreflang="en-us" href="http://test.lo/en-us"/></url>',
             $content

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -98,7 +98,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->dataEn = $this->prepareTestData();
         $this->dataEnUs = $this->prepareTestData('en_us');
 
-        $this->contents = $this->session->getNode('/cmf/sulu_io/contents');
+        $this->contents = $this->session->getNode('/cmf/test_io/contents');
 
         $this->contents->setProperty('i18n:en-state', Structure::STATE_PUBLISHED);
         $this->contents->setProperty('i18n:en-nodeType', Structure::NODE_TYPE_CONTENT);
@@ -123,7 +123,7 @@ class SitemapGeneratorTest extends SuluTestCase
         }
 
         $this->webspace = new Webspace();
-        $this->webspace->setKey('sulu_io');
+        $this->webspace->setKey('test_io');
 
         $local1 = new Localization();
         $local1->setLanguage('en');
@@ -224,7 +224,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $data['news'] = $this->mapper->save(
             $data['news'],
             'overview',
-            'sulu_io',
+            'test_io',
             $locale,
             1,
             true,
@@ -235,7 +235,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $data['news/news-1'] = $this->mapper->save(
             $data['news/news-1'],
             'simple',
-            'sulu_io',
+            'test_io',
             $locale,
             1,
             true,
@@ -246,7 +246,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $data['news/news-2'] = $this->mapper->save(
             $data['news/news-2'],
             'simple',
-            'sulu_io',
+            'test_io',
             $locale,
             1,
             true,
@@ -258,7 +258,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $data['products'] = $this->mapper->save(
             $data['products'],
             'overview',
-            'sulu_io',
+            'test_io',
             $locale,
             1,
             true,
@@ -271,7 +271,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $data['products/products-1'] = $this->mapper->save(
             $data['products/products-1'],
             'overview',
-            'sulu_io',
+            'test_io',
             $locale,
             1,
             true,
@@ -282,7 +282,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $data['products/products-2'] = $this->mapper->save(
             $data['products/products-2'],
             'overview',
-            'sulu_io',
+            'test_io',
             $locale,
             1,
             true,
@@ -294,7 +294,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $data['products/products-3'] = $this->mapper->save(
             $data['products/products-3'],
             'overview',
-            'sulu_io',
+            'test_io',
             $locale,
             1,
             true,
@@ -308,7 +308,7 @@ class SitemapGeneratorTest extends SuluTestCase
 
     public function testGenerateAllFlat()
     {
-        $result = $this->sitemapGenerator->generateAllLocals('sulu_io', true)->getSitemap();
+        $result = $this->sitemapGenerator->generateAllLocals('test_io', true)->getSitemap();
 
         $result = array_map(
             function ($item) {
@@ -334,7 +334,7 @@ class SitemapGeneratorTest extends SuluTestCase
 
     public function testGenerateFlat()
     {
-        $result = $this->sitemapGenerator->generate('sulu_io', 'en', true)->getSitemap();
+        $result = $this->sitemapGenerator->generate('test_io', 'en', true)->getSitemap();
 
         $this->assertCount(6, $result);
         $this->assertEquals('Homepage', $result[0]['title']);
@@ -361,7 +361,7 @@ class SitemapGeneratorTest extends SuluTestCase
 
     public function testGenerateTree()
     {
-        $result = $this->sitemapGenerator->generate('sulu_io', 'en')->getSitemap();
+        $result = $this->sitemapGenerator->generate('test_io', 'en')->getSitemap();
 
         $root = $result;
         $this->assertEquals('Homepage', $root['title']);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/webspaces/sulu_lo.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/webspaces/sulu_lo.xml
@@ -7,9 +7,7 @@
     <key>sulu_io</key>
 
     <localizations>
-        <localization language="en" shadow="auto">
-            <localization language="en" country="us" shadow="auto" default="true"/>
-        </localization>
+        <localization language="en"/>
     </localizations>
 
     <theme>
@@ -44,7 +42,7 @@
             </resource-locator>
 
             <localizations>
-                <localization language="en" default="true"/>
+                <localization language="en"/>
             </localizations>
 
             <environments>

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -870,10 +870,17 @@ class ContentRepositoryTest extends SuluTestCase
         );
 
         $this->assertCount(2, $result);
-        $this->assertArrayHasKey('de_at', $result[0]->getUrls());
-        $this->assertArrayNotHasKey('de', $result[0]->getUrls());
-        $this->assertArrayHasKey('de_at', $result[1]->getUrls());
-        $this->assertArrayNotHasKey('de', $result[1]->getUrls());
+        $urls = $result[0]->getUrls();
+        $this->assertEquals('/test-1', $urls['de_at']);
+        $this->assertNull($urls['de']);
+        $this->assertNull($urls['en']);
+        $this->assertNull($urls['en_us']);
+
+        $urls = $result[1]->getUrls();
+        $this->assertEquals('/', $urls['de_at']);
+        $this->assertEquals('/', $urls['de']);
+        $this->assertEquals('/', $urls['en']);
+        $this->assertEquals('/', $urls['en_us']);
     }
 
     public function testFindUrl()

--- a/src/Sulu/Component/Webspace/Loader/Exception/WebspaceLocalizationNotUsedException.php
+++ b/src/Sulu/Component/Webspace/Loader/Exception/WebspaceLocalizationNotUsedException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Loader\Exception;
+
+use Sulu\Component\Webspace\Webspace;
+
+/**
+ * Thrown if some webspace locales are not used in any portal.
+ */
+class WebspaceLocalizationNotUsedException extends WebspaceException
+{
+    /**
+     * @param Webspace $webspace
+     */
+    public function __construct(Webspace $webspace)
+    {
+        parent::__construct(
+            'The webspace definition for "' . $webspace->getKey() . '" has locales which are not used in any portal'
+        );
+
+        $this->webspace = $webspace;
+    }
+}

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -18,6 +18,7 @@ use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Exception\NoValidWebspaceException;
 use Sulu\Component\Webspace\Loader\Exception\InvalidCustomUrlException;
 use Sulu\Component\Webspace\Loader\Exception\InvalidUrlDefinitionException;
+use Sulu\Component\Webspace\Loader\Exception\WebspaceLocalizationNotUsedException;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Segment;
@@ -137,6 +138,14 @@ class WebspaceCollectionBuilder
                     )
                 );
             } catch (InvalidCustomUrlException $e) {
+                $this->logger->warning(
+                    sprintf(
+                        'Error: "%s" in "%s". The file has been skipped.',
+                        $e->getMessage(),
+                        $file->getRealPath()
+                    )
+                );
+            } catch (WebspaceLocalizationNotUsedException $e) {
                 $this->logger->warning(
                     sprintf(
                         'Error: "%s" in "%s". The file has been skipped.',

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoaderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoaderTest.php
@@ -58,10 +58,12 @@ class XmlFileLoaderTest extends WebspaceTestCase
 
         $this->assertEquals('short', $webspace->getPortals()[0]->getResourceLocatorStrategy());
 
-        $this->assertEquals(1, count($webspace->getPortals()[0]->getLocalizations()));
-        $this->assertEquals('de', $webspace->getPortals()[0]->getLocalizations()[0]->getLanguage());
-        $this->assertEquals('at', $webspace->getPortals()[0]->getLocalizations()[0]->getCountry());
-        $this->assertEquals(true, $webspace->getPortals()[0]->getLocalizations()[0]->isDefault());
+        $this->assertEquals(2, count($webspace->getPortals()[0]->getLocalizations()));
+        $this->assertEquals('en', $webspace->getPortals()[0]->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $webspace->getPortals()[0]->getLocalizations()[0]->getCountry());
+        $this->assertEquals('de', $webspace->getPortals()[0]->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $webspace->getPortals()[0]->getLocalizations()[1]->getCountry());
+        $this->assertEquals(true, $webspace->getPortals()[0]->getLocalizations()[1]->isDefault());
 
         $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocalization());
 
@@ -142,13 +144,17 @@ class XmlFileLoaderTest extends WebspaceTestCase
 
         $this->assertEquals('tree', $webspace->getPortals()[0]->getResourceLocatorStrategy());
 
-        $this->assertEquals(2, count($webspace->getPortals()[0]->getLocalizations()));
+        $this->assertEquals(4, count($webspace->getPortals()[0]->getLocalizations()));
         $this->assertEquals('en', $webspace->getPortals()[0]->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $webspace->getPortals()[0]->getLocalizations()[0]->getCountry());
         $this->assertEquals(false, $webspace->getPortals()[0]->getLocalizations()[0]->isDefault());
-        $this->assertEquals('de', $webspace->getPortals()[0]->getLocalizations()[1]->getLanguage());
-        $this->assertEquals(null, $webspace->getPortals()[0]->getLocalizations()[1]->getCountry());
-        $this->assertEquals(true, $webspace->getPortals()[0]->getLocalizations()[1]->isDefault());
+        $this->assertEquals('en', $webspace->getPortals()[0]->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('ca', $webspace->getPortals()[0]->getLocalizations()[1]->getCountry());
+        $this->assertEquals('fr', $webspace->getPortals()[0]->getLocalizations()[2]->getLanguage());
+        $this->assertEquals('ca', $webspace->getPortals()[0]->getLocalizations()[2]->getCountry());
+        $this->assertEquals('de', $webspace->getPortals()[0]->getLocalizations()[3]->getLanguage());
+        $this->assertEquals(null, $webspace->getPortals()[0]->getLocalizations()[3]->getCountry());
+        $this->assertEquals(true, $webspace->getPortals()[0]->getLocalizations()[3]->isDefault());
 
         $this->assertEquals(2, count($webspace->getNavigation()->getContexts()));
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -79,7 +79,7 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
 
         $prodPortalInformations = $webspaceCollection->getPortalInformations('prod');
 
-        $this->assertCount(8, $prodPortalInformations);
+        $this->assertCount(12, $prodPortalInformations);
 
         $prodPortalInformationKeys = array_keys($prodPortalInformations);
         $prodPortalInformationValues = array_values($prodPortalInformations);
@@ -91,46 +91,79 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $prodPortalInformationValues[3]->getType());
         $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $prodPortalInformationValues[4]->getType());
         $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $prodPortalInformationValues[5]->getType());
-        $this->assertEquals('www.sulu.at', $prodPortalInformationKeys[6]);
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_REDIRECT, $prodPortalInformationValues[6]->getType());
-        $this->assertEquals('sulu.at', $prodPortalInformationKeys[7]);
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $prodPortalInformationValues[7]->getType());
+        $this->assertEquals('www.sulu.at', $prodPortalInformationKeys[10]);
+        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_REDIRECT, $prodPortalInformationValues[10]->getType());
+        $this->assertEquals('sulu.at', $prodPortalInformationKeys[11]);
+        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $prodPortalInformationValues[11]->getType());
 
         $devPortalInformations = $webspaceCollection->getPortalInformations('dev');
 
-        $this->assertCount(9, $devPortalInformations);
+        $this->assertCount(13, $devPortalInformations);
 
-        $devPortalInformationKeys = array_keys($devPortalInformations);
-        /** @var PortalInformation[] $devPortalInformationValues */
-        $devPortalInformationValues = array_values($devPortalInformations);
+        $devPortalInformationValues = [];
+        foreach ($devPortalInformations as $portalInformation) {
+            $devPortalInformationValues[$portalInformation->getUrl()] = array_filter([
+                'type' => $portalInformation->getType(),
+                'redirect' => $portalInformation->getRedirect(),
+                'locale' => $portalInformation->getLocale(),
+            ]);
+        }
 
-        // the values before have the same size, therefore the order cannot be determined
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $devPortalInformationValues[0]->getType());
-        $this->assertNull($devPortalInformationValues[0]->getRedirect());
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $devPortalInformationValues[1]->getType());
-        $this->assertNull($devPortalInformationValues[1]->getRedirect());
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $devPortalInformationValues[2]->getType());
-        $this->assertNull($devPortalInformationValues[2]->getRedirect());
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $devPortalInformationValues[3]->getType());
-        $this->assertNull($devPortalInformationValues[3]->getRedirect());
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $devPortalInformationValues[4]->getType());
-        $this->assertNull($devPortalInformationValues[4]->getRedirect());
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $devPortalInformationValues[5]->getType());
-        $this->assertNull($devPortalInformationValues[5]->getRedirect());
-        $this->assertEquals('massiveart-us.lo', $devPortalInformationKeys[6]);
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, $devPortalInformationValues[6]->getType());
-        $this->assertEquals('massiveart-us.lo/en-us/s', $devPortalInformationValues[6]->getRedirect());
-        $this->assertEquals('massiveart-ca.lo', $devPortalInformationKeys[7]);
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, $devPortalInformationValues[7]->getType());
-        $this->assertEquals('massiveart-ca.lo/fr-ca/s', $devPortalInformationValues[7]->getRedirect());
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, $devPortalInformationValues[7]->getType());
-        $this->assertEquals('sulu.lo', $devPortalInformationKeys[8]);
-        $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $devPortalInformationValues[8]->getType());
+        // massiveart-ca.lo
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'en_ca'],
+            $devPortalInformationValues['massiveart-ca.lo/en-ca/w']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'en_ca'],
+            $devPortalInformationValues['massiveart-ca.lo/en-ca/s']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'fr_ca'],
+            $devPortalInformationValues['massiveart-ca.lo/fr-ca/w']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'fr_ca'],
+            $devPortalInformationValues['massiveart-ca.lo/fr-ca/s']
+        );
 
-        $this->assertEquals('en_us', $devPortalInformationValues[6]->getLocalization()->getLocalization());
-        $this->assertEquals('s', $devPortalInformationValues[6]->getSegment()->getKey());
-        $this->assertEquals('fr_ca', $devPortalInformationValues[7]->getLocalization()->getLocalization());
-        $this->assertEquals('s', $devPortalInformationValues[7]->getSegment()->getKey());
+        // massiveart-us.lo
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'en_ca'],
+            $devPortalInformationValues['massiveart-us.lo/en-ca/w']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'en_ca'],
+            $devPortalInformationValues['massiveart-us.lo/en-ca/s']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'en_us'],
+            $devPortalInformationValues['massiveart-us.lo/en-us/w']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'en_us'],
+            $devPortalInformationValues['massiveart-us.lo/en-us/s']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'fr_ca'],
+            $devPortalInformationValues['massiveart-us.lo/fr-ca/w']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'fr_ca'],
+            $devPortalInformationValues['massiveart-us.lo/fr-ca/s']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, 'locale' => 'fr_ca', 'redirect' => 'massiveart-ca.lo/fr-ca/s'],
+            $devPortalInformationValues['massiveart-ca.lo']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, 'locale' => 'en_us', 'redirect' => 'massiveart-us.lo/en-us/s'],
+            $devPortalInformationValues['massiveart-us.lo']
+        );
+        $this->assertEquals(
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_FULL, 'locale' => 'de_at'],
+            $devPortalInformationValues['sulu.lo']
+        );
     }
 
     public function testBuildWithMultipleLocalizationUrls()

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -107,13 +107,19 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('tree', $portal->getResourceLocatorStrategy());
 
-        $this->assertEquals(2, count($portal->getLocalizations()));
+        $this->assertEquals(4, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
         $this->assertEquals(false, $portal->getLocalizations()[0]->getShadow());
-        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
-        $this->assertEquals(null, $portal->getLocalizations()[1]->getCountry());
+        $this->assertEquals('en', $portal->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('ca', $portal->getLocalizations()[1]->getCountry());
         $this->assertEquals(false, $portal->getLocalizations()[1]->getShadow());
+        $this->assertEquals('fr', $portal->getLocalizations()[2]->getLanguage());
+        $this->assertEquals('ca', $portal->getLocalizations()[2]->getCountry());
+        $this->assertEquals(false, $portal->getLocalizations()[2]->getShadow());
+        $this->assertEquals('de', $portal->getLocalizations()[3]->getLanguage());
+        $this->assertEquals(null, $portal->getLocalizations()[3]->getCountry());
+        $this->assertEquals(false, $portal->getLocalizations()[3]->getShadow());
 
         $this->assertEquals(2, count($portal->getEnvironments()));
 
@@ -189,10 +195,13 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
-        $this->assertEquals(1, count($portal->getLocalizations()));
-        $this->assertEquals('de', $portal->getLocalizations()[0]->getLanguage());
-        $this->assertEquals('at', $portal->getLocalizations()[0]->getCountry());
+        $this->assertEquals(2, count($portal->getLocalizations()));
+        $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
         $this->assertEquals('', $portal->getLocalizations()[0]->getShadow());
+        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $portal->getLocalizations()[1]->getCountry());
+        $this->assertEquals('', $portal->getLocalizations()[1]->getShadow());
 
         $this->assertEquals(3, count($portal->getEnvironments()));
 
@@ -218,10 +227,13 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
-        $this->assertEquals(1, count($portal->getLocalizations()));
-        $this->assertEquals('de', $portal->getLocalizations()[0]->getLanguage());
-        $this->assertEquals('at', $portal->getLocalizations()[0]->getCountry());
+        $this->assertEquals(2, count($portal->getLocalizations()));
+        $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
         $this->assertEquals('', $portal->getLocalizations()[0]->getShadow());
+        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $portal->getLocalizations()[1]->getCountry());
+        $this->assertEquals('', $portal->getLocalizations()[1]->getShadow());
 
         $this->assertCount(3, $portal->getEnvironments());
 
@@ -278,10 +290,13 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
-        $this->assertEquals(1, count($portal->getLocalizations()));
-        $this->assertEquals('de', $portal->getLocalizations()[0]->getLanguage());
-        $this->assertEquals('at', $portal->getLocalizations()[0]->getCountry());
+        $this->assertEquals(2, count($portal->getLocalizations()));
+        $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
         $this->assertEquals('', $portal->getLocalizations()[0]->getShadow());
+        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $portal->getLocalizations()[1]->getCountry());
+        $this->assertEquals('', $portal->getLocalizations()[1]->getShadow());
 
         $this->assertCount(3, $portal->getEnvironments());
 
@@ -323,10 +338,13 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
-        $this->assertEquals(1, count($portal->getLocalizations()));
-        $this->assertEquals('de', $portal->getLocalizations()[0]->getLanguage());
-        $this->assertEquals('at', $portal->getLocalizations()[0]->getCountry());
+        $this->assertEquals(2, count($portal->getLocalizations()));
+        $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
         $this->assertEquals('', $portal->getLocalizations()[0]->getShadow());
+        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $portal->getLocalizations()[1]->getCountry());
+        $this->assertEquals('', $portal->getLocalizations()[1]->getShadow());
 
         $this->assertEquals(3, count($portal->getEnvironments()));
 
@@ -401,13 +419,19 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('tree', $portal->getResourceLocatorStrategy());
 
-        $this->assertEquals(2, count($portal->getLocalizations()));
+        $this->assertEquals(4, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
         $this->assertEquals(false, $portal->getLocalizations()[0]->getShadow());
-        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
-        $this->assertEquals(null, $portal->getLocalizations()[1]->getCountry());
+        $this->assertEquals('en', $portal->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('ca', $portal->getLocalizations()[1]->getCountry());
         $this->assertEquals(false, $portal->getLocalizations()[1]->getShadow());
+        $this->assertEquals('fr', $portal->getLocalizations()[2]->getLanguage());
+        $this->assertEquals('ca', $portal->getLocalizations()[2]->getCountry());
+        $this->assertEquals(false, $portal->getLocalizations()[2]->getShadow());
+        $this->assertEquals('de', $portal->getLocalizations()[3]->getLanguage());
+        $this->assertEquals(null, $portal->getLocalizations()[3]->getCountry());
+        $this->assertEquals(false, $portal->getLocalizations()[3]->getShadow());
 
         $this->assertCount(2, $portal->getEnvironments());
 

--- a/tests/Resources/DataFixtures/Webspace/both/massiveart.xml
+++ b/tests/Resources/DataFixtures/Webspace/both/massiveart.xml
@@ -53,6 +53,8 @@
 
             <localizations>
                 <localization language="en" country="us"/>
+                <localization language="en" country="ca"/>
+                <localization language="fr" country="ca"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/both/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/both/sulu.io.xml
@@ -45,7 +45,8 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withIncorrectUrls.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withIncorrectUrls.xml
@@ -54,7 +54,9 @@
 
             <localizations>
                 <localization language="en" country="us"/>
-                <localization language="de" />
+                <localization language="en" country="ca"/>
+                <localization language="fr" country="ca"/>
+                <localization language="de"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withNotExistingDefaultSegment.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withNotExistingDefaultSegment.xml
@@ -52,7 +52,8 @@
             </resource-locator>
 
             <localizations>
-                <localization language="en" country="ca" default="true"/>
+                <localization language="en" country="us"/>
+                <localization language="en" country="ca"/>
                 <localization language="fr" country="ca"/>
             </localizations>
 

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withTwoDefaultLocalizations.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withTwoDefaultLocalizations.xml
@@ -53,6 +53,8 @@
 
             <localizations>
                 <localization language="en" country="us"/>
+                <localization language="en" country="ca"/>
+                <localization language="fr" country="ca"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withoutDefaultLocalization.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withoutDefaultLocalization.xml
@@ -53,6 +53,8 @@
 
             <localizations>
                 <localization language="en" country="us"/>
+                <localization language="en" country="ca"/>
+                <localization language="fr" country="ca"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_error_templates_default_false.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_error_templates_default_false.xml
@@ -55,7 +55,9 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="en" country="ca"/>
+                <localization language="fr" country="ca"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_error_templates_many_defaults.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_error_templates_many_defaults.xml
@@ -55,7 +55,9 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="en" country="ca"/>
+                <localization language="fr" country="ca"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/main/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/main/sulu.io.xml
@@ -49,7 +49,8 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/url-with-trailing-slash/sulu.io_url_with_slash.xml
+++ b/tests/Resources/DataFixtures/Webspace/url-with-trailing-slash/sulu.io_url_with_slash.xml
@@ -45,7 +45,8 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/valid/dan.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/dan.io.xml
@@ -49,7 +49,8 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/valid/massiveart.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/massiveart.xml
@@ -58,7 +58,9 @@
 
             <localizations>
                 <localization language="en" country="us"/>
-                <localization language="de" />
+                <localization language="en" country="ca"/>
+                <localization language="fr" country="ca"/>
+                <localization language="de" default="true"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
@@ -49,7 +49,8 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_error_templates.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_error_templates.xml
@@ -55,7 +55,8 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_error_templates_default_only.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_error_templates_default_only.xml
@@ -53,7 +53,8 @@
             </resource-locator>
 
             <localizations>
-                <localization language="de" country="at"/>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
             </localizations>
 
             <environments>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_error_templates_missing_default.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_error_templates_missing_default.xml
@@ -54,6 +54,7 @@
             </resource-locator>
 
             <localizations>
+                <localization language="en" country="us"/>
                 <localization language="de" country="at"/>
             </localizations>
 

--- a/tests/app/Resources/webspaces/sulu.io.xml
+++ b/tests/app/Resources/webspaces/sulu.io.xml
@@ -48,6 +48,9 @@
 
             <localizations>
                 <localization language="de" country="at" default="true"/>
+                <localization language="en"/>
+                <localization language="en" country="us"/>
+                <localization language="de"/>
             </localizations>
 
             <environments>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes => see UPGRADE
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu-io/sulu-standard/pull/643
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a validation for webspaces that all locales have to be used in the portals.

#### Why?

If there are locales without portal the preview throws a strange error.