### PR TITLE
IP-Anonymization for Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGIFX      #2178 [WebsiteBundle]       Added default IP anonymization for google analytics
     * BUGFIX      #2171 [ContentBundle]       Fixed saving of homepage
     * BUGFIX      #2172 [CustomUrlBundle]     Added check for custom-url placeholder
     * BUGFIX      #2166 [WebsiteBundle]       Fixed analytics type change

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/type/google.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/type/google.html.twig
@@ -5,6 +5,7 @@
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
     ga('create', '{{ analytics.content }}', 'auto');
+    ga('set', 'anonymizeIp', true);
     ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds the anonymizeIp option to the default google analytics template.

#### Why?

It is required within europe.