### PR TITLE
Fixed resolve sulu_resolve_user function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #2183 [ContentBundle]       Added missing locale for loading route document
     * BUGFIX      #2185 [MediaBundle]         Fixed throw exception if new version has a different media type
-    * BUGIFX      #2178 [WebsiteBundle]       Added default IP anonymization for google analytics
+    * ENHANCEMENT #2182 [ContactBundle]       Added `sulu_resolve_contact` twig function
+    * ENHANCEMENT #2182 [SecurityBundle]      Fixed `sulu_resolve_user` twig function to return a user instead of a contact
+    * BUGFIX      #2178 [WebsiteBundle]       Added default IP anonymization for google analytics
     * BUGFIX      #2171 [ContentBundle]       Fixed saving of homepage
     * BUGFIX      #2172 [CustomUrlBundle]     Added check for custom-url placeholder
     * BUGFIX      #2166 [WebsiteBundle]       Fixed analytics type change

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,14 @@
 
 ## dev-develop
 
+### Twig function `sulu_resolve_user`
+
+This twig function returns now the user. To get the related contact use following code snippet:
+
+```twig
+{{ sulu_resolve_user(userId).contact.fullName }}
+```
+
 ### New security permission for cache
  
 To be able to clear the cache the user need the permission LIVE in the

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -86,9 +86,10 @@
         </service>
         <service id="sulu_contact.twig.cache" class="%sulu_contact.twig.cache.class%"/>
         <service id="sulu_contact.twig" class="%sulu_contact.twig.class%">
-            <tag name="twig.extension"/>
             <argument type="service" id="sulu_contact.twig.cache"/>
-            <argument type="service" id="sulu.repository.user"/>
+            <argument type="service" id="sulu.repository.contact"/>
+
+            <tag name="twig.extension"/>
         </service>
 
         <service id="sulu_contact.account_factory" class="%sulu_contact.account_factory.class%"/>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
@@ -15,9 +15,8 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use PHPUnit_Framework_TestCase;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
 use Sulu\Bundle\ContactBundle\Twig\ContactTwigExtension;
-use Sulu\Bundle\SecurityBundle\Entity\User;
-use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
 
 class ContactTwigExtensionTest extends PHPUnit_Framework_TestCase
 {
@@ -32,61 +31,41 @@ class ContactTwigExtensionTest extends PHPUnit_Framework_TestCase
     private $cache;
 
     /**
-     * @var UserRepository
+     * @var ContactRepository
      */
-    private $userRepository;
+    private $contactRepository;
 
     protected function setUp()
     {
         $this->cache = new ArrayCache();
-        $this->userRepository = $this->getMock(
-            'Sulu\Bundle\SecurityBundle\Entity\UserRepository',
-            ['findUserById'],
-            [],
-            'UserRepositoryMock',
-            false,
-            false
-        );
+        $this->contactRepository = $this->prophesize(ContactRepository::class);
 
-        $this->extension = new ContactTwigExtension($this->cache, $this->userRepository);
+        $this->extension = new ContactTwigExtension($this->cache, $this->contactRepository->reveal());
     }
 
-    public function testResolveUserFunction()
+    public function testResolveContactFunction()
     {
-        $user1 = new User();
         $contact1 = new Contact();
         $contact1->setFirstName('Hikaru');
         $contact1->setLastName('Sulu');
-        $user1->setContact($contact1);
 
-        $user2 = new User();
         $contact2 = new Contact();
         $contact2->setFirstName('John');
         $contact2->setLastName('Cho');
-        $user2->setContact($contact2);
 
-        $this->userRepository
-            ->expects($this->exactly(2))
-            ->method('findUserById')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        [1, $user1],
-                        [2, $user2],
-                    ]
-                )
-            );
+        $this->contactRepository->find(1)->willReturn($contact1);
+        $this->contactRepository->find(2)->willReturn($contact2);
 
-        $contact = $this->extension->resolveUserFunction(1);
+        $contact = $this->extension->resolveContactFunction(1);
         $this->assertEquals('Hikaru Sulu', $contact->getFullName());
 
-        $contact = $this->extension->resolveUserFunction(2);
+        $contact = $this->extension->resolveContactFunction(2);
         $this->assertEquals('John Cho', $contact->getFullName());
     }
 
-    public function testResolveUserFunctionNonExisting()
+    public function testResolveContactFunctionNonExisting()
     {
-        $contact = $this->extension->resolveUserFunction(3);
+        $contact = $this->extension->resolveContactFunction(3);
         $this->assertNull($contact);
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\ContactBundle\Twig;
 
 use Doctrine\Common\Cache\Cache;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
-use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
+use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
 
 /**
  * Extension to handle contacts in frontend.
@@ -21,19 +21,19 @@ use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
 class ContactTwigExtension extends \Twig_Extension
 {
     /**
-     * @var UserRepository
+     * @var ContactRepository
      */
-    private $userRepository;
+    private $contactRepository;
 
     /**
      * @var Cache
      */
     private $cache;
 
-    public function __construct(Cache $cache, UserRepository $userRepository)
+    public function __construct(Cache $cache, ContactRepository $contactRepository)
     {
         $this->cache = $cache;
-        $this->userRepository = $userRepository;
+        $this->contactRepository = $contactRepository;
     }
 
     /**
@@ -42,30 +42,31 @@ class ContactTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_resolve_user', [$this, 'resolveUserFunction']),
+            new \Twig_SimpleFunction('sulu_resolve_contact', [$this, 'resolveContactFunction']),
         ];
     }
 
     /**
      * resolves user id to user data.
      *
-     * @param int $userId id to resolve
+     * @param int $id id to resolve
      *
      * @return Contact
      */
-    public function resolveUserFunction($userId)
+    public function resolveContactFunction($id)
     {
-        if (!$this->cache->contains($userId)) {
-            $user = $this->userRepository->findUserById($userId);
-
-            if ($user === null) {
-                return;
-            }
-
-            $this->cache->save($userId, $user->getContact());
+        if ($this->cache->contains($id)) {
+            return $this->cache->fetch($id);
         }
 
-        return $this->cache->fetch($userId);
+        $contact = $this->contactRepository->find($id);
+        if ($contact === null) {
+            return;
+        }
+
+        $this->cache->save($id, $contact);
+
+        return $contact;
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -166,5 +166,13 @@
             <argument type="service" id="security.token_storage" on-invalid="null"/>
             <tag name="jms_serializer.event_subscriber"/>
         </service>
+
+        <service id="sulu_security.twig_extension.user.cache" class="Doctrine\Common\Cache\ArrayCache"/>
+        <service id="sulu_security.twig_extension.user" class="Sulu\Bundle\SecurityBundle\Twig\UserTwigExtension">
+            <argument type="service" id="sulu_security.twig_extension.user.cache"/>
+            <argument type="service" id="sulu.repository.user"/>
+
+            <tag name="twig.extension"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\Twig;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Cache;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
+use Sulu\Bundle\SecurityBundle\Twig\UserTwigExtension;
+
+class UserTwigExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var UserTwigExtension
+     */
+    private $extension;
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    /**
+     * @var UserRepository
+     */
+    private $userRepository;
+
+    protected function setUp()
+    {
+        $this->cache = new ArrayCache();
+        $this->userRepository = $this->prophesize(UserRepository::class);
+
+        $this->extension = new UserTwigExtension($this->cache, $this->userRepository->reveal());
+    }
+
+    public function testResolveUserFunction()
+    {
+        $user1 = new User();
+        $user1->setUsername('hikaru');
+
+        $user2 = new User();
+        $user2->setUsername('sulu');
+
+        $this->userRepository->findUserById(1)->willReturn($user1);
+        $this->userRepository->findUserById(2)->willReturn($user2);
+
+        $user = $this->extension->resolveUserFunction(1);
+        $this->assertEquals('hikaru', $user->getUsername());
+
+        $user = $this->extension->resolveUserFunction(2);
+        $this->assertEquals('sulu', $user->getUsername());
+    }
+
+    public function testResolveUserFunctionNonExisting()
+    {
+        $user = $this->extension->resolveUserFunction(3);
+        $this->assertNull($user);
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Twig;
+
+use Doctrine\Common\Cache\Cache;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
+
+/**
+ * Extension to handle users in frontend.
+ */
+class UserTwigExtension extends \Twig_Extension
+{
+    /**
+     * @var UserRepository
+     */
+    private $userRepository;
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    public function __construct(Cache $cache, UserRepository $userRepository)
+    {
+        $this->cache = $cache;
+        $this->userRepository = $userRepository;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('sulu_resolve_user', [$this, 'resolveUserFunction']),
+        ];
+    }
+
+    /**
+     * resolves user id to user data.
+     *
+     * @param int $id id to resolve
+     *
+     * @return User
+     */
+    public function resolveUserFunction($id)
+    {
+        if ($this->cache->contains($id)) {
+            return $this->cache->fetch($id);
+        }
+
+        $user = $this->userRepository->findUserById($id);
+        if ($user === null) {
+            return;
+        }
+
+        $this->cache->save($id, $user);
+
+        return $user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sulu_user';
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2089 
| Related issues/PRs | https://github.com/sulu-io/sulu-standard/pull/645
| License | MIT
| Documentation PR | https://github.com/sulu-io/sulu-docs/pull/191

#### What's in this PR?

This PR fixes the behavior of the `sulu_resolve_user` function.

#### Why?

The old version of this function returns the contact and you cannot get the user. This PR introduces a function `sulu_resolve_contact` function which returns a contact and it fixes the `sulu_resolve_user` to return a user.

#### Example Usage

~~~php
{{ sulu_resolve_user(userId).contact.fullName }}
~~~

#### BC Breaks/Deprecations

The `sulu_resolve_user` returns now the user to get the contact call `.contact` and the you can use it like before (see example of UPGRADE)
