### PR TITLE
added missing locale for loading route document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2183 [ContentBundle]       Added missing locale for loading route document
     * BUGIFX      #2178 [WebsiteBundle]       Added default IP anonymization for google analytics
     * BUGFIX      #2171 [ContentBundle]       Fixed saving of homepage
     * BUGFIX      #2172 [CustomUrlBundle]     Added check for custom-url placeholder

--- a/src/Sulu/Component/Content/Types/Rlp/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/Rlp/Mapper/PhpcrMapper.php
@@ -74,7 +74,7 @@ class PhpcrMapper extends RlpMapper
 
             $routeDocument = $this->documentManager->find(
                 $webspaceRouteRootPath . $routeNodePath,
-                null,
+                $locale,
                 ['rehydrate' => false]
             );
             $routeDocumentPath = $webspaceRouteRootPath . $routeNodePath;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes behat tests
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Adds a missing locale parameter to a load for routing documents.

#### Why?

The behat tests are broken because of that.