### PR TITLE
Fixed wrong translator locale by decorating translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2190 [WebsiteBundle]       Fixed wrong translator locale by decorating translator
     * BUGFIX      #2183 [ContentBundle]       Added missing locale for loading route document
     * BUGFIX      #2185 [MediaBundle]         Fixed throw exception if new version has a different media type
     * ENHANCEMENT #2182 [ContactBundle]       Added `sulu_resolve_contact` twig function

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -185,5 +185,11 @@
             <argument type="string">%kernel.environment%</argument>
             <argument type="service" id="filesystem"/>
         </service>
+
+        <service id="sulu_website.translator.request_analyzer"
+                 class="Sulu\Bundle\WebsiteBundle\Translator\RequestAnalyzerTranslator" decorates="translator">
+            <argument type="service" id="sulu_website.translator.request_analyzer.inner"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Translator/RequestAnalyzerTranslatorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Translator/RequestAnalyzerTranslatorTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\Translator;
+
+use Sulu\Bundle\WebsiteBundle\Translator\RequestAnalyzerTranslator;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class RequestAnalyzerTranslatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetLocale()
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzerTranslator = new RequestAnalyzerTranslator($translator->reveal(), $requestAnalyzer->reveal());
+
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $translator->setLocale('de')->shouldBeCalledTimes(1);
+        $translator->getLocale()->willReturn('de');
+
+        $this->assertEquals('de', $requestAnalyzerTranslator->getLocale());
+    }
+
+    public function testGetLocaleTwice()
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzerTranslator = new RequestAnalyzerTranslator($translator->reveal(), $requestAnalyzer->reveal());
+
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $translator->setLocale('de')->shouldBeCalledTimes(1);
+        $translator->getLocale()->willReturn('de');
+
+        $this->assertEquals('de', $requestAnalyzerTranslator->getLocale());
+        $this->assertEquals('de', $requestAnalyzerTranslator->getLocale());
+    }
+
+    public function testSetLocale()
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzerTranslator = new RequestAnalyzerTranslator($translator->reveal(), $requestAnalyzer->reveal());
+
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $translator->setLocale('de')->shouldNotBeCalled();
+        $translator->setLocale('en')->shouldBeCalled();
+
+        $requestAnalyzerTranslator->setLocale('en');
+    }
+
+    public function testSetLocaleTwice()
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzerTranslator = new RequestAnalyzerTranslator($translator->reveal(), $requestAnalyzer->reveal());
+
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $translator->setLocale('de')->shouldNotBeCalled();
+        $translator->setLocale('en')->shouldBeCalled();
+
+        $requestAnalyzerTranslator->setLocale('en');
+        $requestAnalyzerTranslator->setLocale('en');
+    }
+
+    public function testTrans()
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzerTranslator = new RequestAnalyzerTranslator($translator->reveal(), $requestAnalyzer->reveal());
+
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $translator->setLocale('de')->shouldBeCalledTimes(1);
+        $translator->trans('folder', ['test-1'], 'messages', 'de')->willReturn('Ordner');
+
+        $this->assertEquals('Ordner', $requestAnalyzerTranslator->trans('folder', ['test-1'], 'messages', 'de'));
+    }
+
+    public function testTransTwice()
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzerTranslator = new RequestAnalyzerTranslator($translator->reveal(), $requestAnalyzer->reveal());
+
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $translator->setLocale('de')->shouldBeCalledTimes(1);
+        $translator->trans('folder', ['test-1'], 'messages', 'de')->willReturn('Ordner');
+
+        $this->assertEquals('Ordner', $requestAnalyzerTranslator->trans('folder', ['test-1'], 'messages', 'de'));
+        $this->assertEquals('Ordner', $requestAnalyzerTranslator->trans('folder', ['test-1'], 'messages', 'de'));
+    }
+
+    public function testTransChoice()
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzerTranslator = new RequestAnalyzerTranslator($translator->reveal(), $requestAnalyzer->reveal());
+
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $translator->setLocale('de')->shouldBeCalledTimes(1);
+        $translator->transChoice('folder', 2, ['test-1'], 'messages', 'de')->willReturn('Ordner');
+
+        $this->assertEquals(
+            'Ordner',
+            $requestAnalyzerTranslator->transChoice('folder', 2, ['test-1'], 'messages', 'de')
+        );
+    }
+
+    public function testTransChoiceTwice()
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzerTranslator = new RequestAnalyzerTranslator($translator->reveal(), $requestAnalyzer->reveal());
+
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $translator->setLocale('de')->shouldBeCalledTimes(1);
+        $translator->transChoice('folder', 2, ['test-1'], 'messages', 'de')->willReturn('Ordner');
+
+        $this->assertEquals(
+            'Ordner',
+            $requestAnalyzerTranslator->transChoice('folder', 2, ['test-1'], 'messages', 'de')
+        );
+        $this->assertEquals(
+            'Ordner',
+            $requestAnalyzerTranslator->transChoice('folder', 2, ['test-1'], 'messages', 'de')
+        );
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Translator/RequestAnalyzerTranslator.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Translator/RequestAnalyzerTranslator.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Translator;
+
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Wrapper for translator to lazy initialize locale with request-analyzer.
+ */
+class RequestAnalyzerTranslator implements TranslatorInterface
+{
+    /**
+     * @var bool
+     */
+    private $initialized = false;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    public function __construct(TranslatorInterface $translator, RequestAnalyzerInterface $requestAnalyzer)
+    {
+        $this->translator = $translator;
+        $this->requestAnalyzer = $requestAnalyzer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    {
+        $this->initialize();
+
+        return $this->translator->trans($id, $parameters, $domain, $locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+    {
+        $this->initialize();
+
+        return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocale($locale)
+    {
+        // don't initialize here because of the TranslateListener (will be called on every request)
+
+        return $this->translator->setLocale($locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+        $this->initialize();
+
+        return $this->translator->getLocale();
+    }
+
+    private function initialize()
+    {
+        if ($this->initialized || $this->requestAnalyzer->getCurrentLocalization() === null) {
+            return;
+        }
+
+        $this->translator->setLocale($this->requestAnalyzer->getCurrentLocalization()->getLocalization());
+        $this->initialized = true;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2188
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR decorates the translator and lazy initialize the locale of it.

#### Why?

Because if you use for example in our sulu-standard `SearchController` the translator service you get all messages in the default locale (mostly en) and not in the content language. This is because the translator uses the request to determine the locale on kernel request. This PR set the locale to the locale of the reuquest-analyzer by wrapping it and set the locale to the locale of the request-analyzer.

#### To Do

- [x] Tests