### PR TITLE
X-Powered-By HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2192 [WebsiteBundle]       Added X-Generator HTTP header for Sulu website detection
     * BUGFIX      #2183 [ContentBundle]       Added missing locale for loading route document
     * BUGFIX      #2185 [MediaBundle]         Fixed throw exception if new version has a different media type
     * ENHANCEMENT #2182 [ContactBundle]       Added `sulu_resolve_contact` twig function

--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddJsConfigPass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ContentNavigationPass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\WidgetsPass;
-use Sulu\Component\Util\SuluVersionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -29,6 +28,5 @@ class SuluAdminBundle extends Bundle
         $container->addCompilerPass(new AddJsConfigPass());
         $container->addCompilerPass(new ContentNavigationPass());
         $container->addCompilerPass(new WidgetsPass());
-        $container->addCompilerPass(new SuluVersionPass());
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/AnalyticsSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/AnalyticsSerializeEventSubscriber.php
@@ -8,7 +8,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\WebsiteBundle\EventListener;
+namespace Sulu\Bundle\WebsiteBundle\EventSubscriber;
 
 use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;

--- a/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/GeneratorEventSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/GeneratorEventSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds the X-Generator header.
+ */
+class GeneratorEventSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var string
+     */
+    private $version;
+
+    /**
+     * @param $version
+     */
+    public function __construct($version)
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => 'onResponse',
+        ];
+    }
+
+    /**
+     * @param FilterResponseEvent $event
+     */
+    public function onResponse(FilterResponseEvent $event)
+    {
+        $event->getResponse()->headers->set('X-Generator', 'Sulu/' . $this->version);
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/analytics.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/analytics.xml
@@ -11,26 +11,27 @@
 
         <service id="sulu_website.analytics.repository"
                  class="Sulu\Bundle\WebsiteBundle\Entity\AnalyticsRepository">
-            <factory service="doctrine.orm.entity_manager" method="getRepository" />
+            <factory service="doctrine.orm.entity_manager" method="getRepository"/>
 
             <argument type="string">SuluWebsiteBundle:Analytics</argument>
         </service>
 
         <service id="sulu_website.domains.repository"
                  class="Sulu\Bundle\WebsiteBundle\Entity\DomainRepository">
-            <factory service="doctrine.orm.entity_manager" method="getRepository" />
+            <factory service="doctrine.orm.entity_manager" method="getRepository"/>
 
             <argument type="string">SuluWebsiteBundle:Domain</argument>
         </service>
 
         <service id="sulu_website.analytics.manager"
                  class="Sulu\Bundle\WebsiteBundle\Analytics\AnalyticsManager">
-            <argument type="service" id="doctrine.orm.entity_manager" />
-            <argument type="service" id="sulu_website.analytics.repository" />
-            <argument type="service" id="sulu_website.domains.repository" />
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="sulu_website.analytics.repository"/>
+            <argument type="service" id="sulu_website.domains.repository"/>
         </service>
 
-        <service id="sulu_wesite.analytics.response_listener" class="Sulu\Bundle\WebsiteBundle\EventListener\AppendAnalyticsListener">
+        <service id="sulu_website.analytics.response_listener"
+                 class="Sulu\Bundle\WebsiteBundle\EventListener\AppendAnalyticsListener">
             <argument type="service" id="templating"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.analytics.repository"/>
@@ -40,9 +41,9 @@
             <tag name="kernel.event_listener" event="kernel.response" method="onResponse" priority="-5"/>
         </service>
 
-        <service id="sulu_wesite.analytics.event_subscriber"
-                 class="Sulu\Bundle\WebsiteBundle\EventListener\AnalyticsSerializeEventSubscriber">
-            <tag name="jms_serializer.event_subscriber" />
+        <service id="sulu_website.analytics.event_subscriber"
+                 class="Sulu\Bundle\WebsiteBundle\EventSubscriber\AnalyticsSerializeEventSubscriber">
+            <tag name="jms_serializer.event_subscriber"/>
             <tag name="sulu.context" context="admin"/>
         </service>
     </services>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
@@ -11,7 +11,7 @@
     <services>
         <!-- request analyzer data collector -->
         <service id="sulu_website.data_collector.sulu_collector" class="%sulu_website.data_collector.sulu_collector.class%">
-            <argument type="service" id="sulu_core.webspace.request_analyzer" />
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
 
             <tag name="data_collector" template="SuluWebsiteBundle:Profiler:layout" id="sulu"/>
             <tag name="sulu.context" context="website"/>
@@ -38,6 +38,14 @@
             <argument type="service" id="liip_theme.active_theme"/>
 
             <tag name="kernel.event_listener" event="%sulu_website.engine.initialize%" method="setActiveTheme"/>
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_website.generator.event_subscriber"
+                 class="Sulu\Bundle\WebsiteBundle\EventSubscriber\GeneratorEventSubscriber">
+            <argument>%sulu.version%</argument>
+
+            <tag name="kernel.event_subscriber"/>
             <tag name="sulu.context" context="website"/>
         </service>
     </services>

--- a/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
+++ b/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
@@ -11,8 +11,19 @@
 
 namespace Sulu\Bundle\WebsiteBundle;
 
+use Sulu\Component\Util\SuluVersionPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SuluWebsiteBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new SuluVersionPass());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #1247
| License | MIT

#### What's in this PR?

Adds the X-Powered-By HTTP header which can be used for Wappalyzer Sulu detection. (https://wappalyzer.com)

#### Why?

Sulu website detection.
