### PR TITLE
Fixed issue with workspace not being defined

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Initializer/WorkspaceInitializer.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Initializer/WorkspaceInitializer.php
@@ -36,6 +36,8 @@ class WorkspaceInitializer implements InitializerInterface
     public function initialize(OutputInterface $output)
     {
         foreach ($this->registry->getConnections() as $connection) {
+            $workspace = $connection->getWorkspace();
+
             try {
                 $connection->getRootNode();
                 $output->writeln(sprintf('  [ ] <info>workspace</info>: "%s"', $workspace->getName()));
@@ -43,7 +45,6 @@ class WorkspaceInitializer implements InitializerInterface
                 // TODO: We should catch the more explicit
                 // WorkspaceNotFoundException but Jackalope doctrine-dbal does
                 // not throw this: https://github.com/jackalope/jackalope-doctrine-dbal/issues/322
-                $workspace = $connection->getWorkspace();
                 $workspace->createWorkspace($workspace->getName());
                 $output->writeln(sprintf('  [+] <info>workspace</info>: "%s"', $workspace->getName()));
             }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
@@ -16,7 +16,6 @@ use PHPCR\RepositoryException;
 use PHPCR\SessionInterface;
 use PHPCR\WorkspaceInterface;
 use Sulu\Bundle\DocumentManagerBundle\Initializer\WorkspaceInitializer;
-use Sulu\Component\DocumentManager\PathSegmentRegistry;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 class WorkspaceInitializerTest extends \PHPUnit_Framework_TestCase
@@ -37,11 +36,6 @@ class WorkspaceInitializerTest extends \PHPUnit_Framework_TestCase
     private $connectionRegistry;
 
     /**
-     * @var PathSegmentRegistry
-     */
-    private $segmentRegistry;
-
-    /**
      * @var WorkspaceInitializer
      */
     private $initializer;
@@ -49,14 +43,20 @@ class WorkspaceInitializerTest extends \PHPUnit_Framework_TestCase
     /**
      * @var WorkspaceInterface
      */
-    private $workspace;
+    private $workspace1;
+
+    /**
+     * @var WorkspaceInterface
+     */
+    private $workspace2;
 
     public function setUp()
     {
         $this->session1 = $this->prophesize(SessionInterface::class);
         $this->session2 = $this->prophesize(SessionInterface::class);
         $this->connectionRegistry = $this->prophesize(ConnectionRegistry::class);
-        $this->workspace = $this->prophesize(WorkspaceInterface::class);
+        $this->workspace1 = $this->prophesize(WorkspaceInterface::class);
+        $this->workspace2 = $this->prophesize(WorkspaceInterface::class);
         $this->output = new BufferedOutput();
 
         $this->initializer = new WorkspaceInitializer(
@@ -66,7 +66,6 @@ class WorkspaceInitializerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * It should create the workspace on connections with non-existing workspaces.
-     * It should skip connections with existing workspaces.
      */
     public function testCreateWorkspace()
     {
@@ -78,10 +77,13 @@ class WorkspaceInitializerTest extends \PHPUnit_Framework_TestCase
         $this->session1->getRootNode()->willThrow(new RepositoryException('Foo'));
         $this->session2->getRootNode()->willReturn(true);
 
-        $this->session1->getWorkspace()->willReturn($this->workspace->reveal());
-        $this->session2->getWorkspace()->shouldNotBeCalled();
-        $this->workspace->getName()->willReturn('hello');
-        $this->workspace->createWorkspace('hello')->shouldBeCalled();
+        $this->session1->getWorkspace()->willReturn($this->workspace1->reveal());
+        $this->session2->getWorkspace()->willReturn($this->workspace2->reveal());
+
+        $this->workspace1->getName()->willReturn('hello1');
+        $this->workspace2->getName()->willReturn('hello2');
+        $this->workspace1->createWorkspace('hello1')->shouldBeCalled();
+        $this->workspace2->createWorkspace('hello2')->shouldNotBeCalled();
 
         $this->initializer->initialize($this->output);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu-io/sulu-docs#prnum

#### What's in this PR?

Quick fix for regression whereby the `$workspace` was not defined (code path was not tested where by the first session did not throw an exception).
